### PR TITLE
Fixing unexisting variables in Ruby mspoller example.

### DIFF
--- a/examples/Ruby/mspoller.rb
+++ b/examples/Ruby/mspoller.rb
@@ -26,10 +26,10 @@ poller.register(subscriber, ZMQ::POLLIN)
 while true
   poller.poll(:blocking)
   poller.readables.each do |socket|
-    if socket === frontend
+    if socket === reciever
       message = socket.recv_string
       # process task
-    elsif socket === backend
+    elsif socket === subscriber
       message = socket.recv_string
       # process weather update
     end


### PR DESCRIPTION
That were just typos needed to be fixed.
