### PR TITLE
Minor fixes to perl example

### DIFF
--- a/examples/Perl/taskvent.pl
+++ b/examples/Perl/taskvent.pl
@@ -36,9 +36,6 @@ say 'Sending tasks to workers...';
 # The first message is "0" and signals start of batch
 $sender->send('0');
 
-# Initialize random number generator
-srand();
-
 # Send 100 tasks
 my $total_msec = 0;     # Total expected cost in msecs
 for (1 .. 100) {


### PR DESCRIPTION
Removed unnecessary call to srand, which perl handles on first rand call.
Fixed workload to match described behaviour (range 1-100 from 1-101)
