### PR TITLE
Samples in Scala up to chapter 3

### DIFF
--- a/examples/scala/Dns.scala
+++ b/examples/scala/Dns.scala
@@ -1,0 +1,39 @@
+/*
+ *  Micro DNS for resolving connection endpoints
+ *
+ *
+ *
+ * @Author:     Giovanni Ruggiero
+ * @Email:      giovanni.ruggiero@gmail.com
+*/
+
+class Dns(hosts: Map[String,(String,Int)], ports: Map[String,String]) {
+	private def getHost(hostName: String) = hosts(hostName)._1
+
+	def endPoint(host: String, port: String) =  "tcp://" + getHost(host) + ":" + ports(port) + hosts(host)._2
+
+	def bind(host: String, port: String) = "tcp://*:" + ports(port) + hosts(host)._2
+
+}
+
+object ClusterDns {
+
+	private val hosts = Map(
+		"DC1"  -> ("localhost", 1),
+		"DC2"  -> ("localhost", 2),
+		"DC3"  -> ("localhost", 3)
+	)
+
+	val ports = Map(
+		"statefe" -> "5550",
+		"statebe" -> "5550",
+		"localfe" -> "5551",
+		"localbe" -> "5552",
+		"cloudfe" -> "5553",
+		"cloudbe" -> "5553"
+	)
+
+	val clusterDns = new Dns(hosts,ports)
+
+}
+

--- a/examples/scala/MsgQueue.scala
+++ b/examples/scala/MsgQueue.scala
@@ -1,0 +1,39 @@
+s/**
+ * Simple message queuing broker
+ * Same as request-reply broker but using QUEUE device.
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+ */
+
+import org.zeromq.ZMQ
+import org.zeromq.ZMQ.Context
+import org.zeromq.ZMQ.Socket
+import org.zeromq.ZMQQueue
+
+object MsgQueue {
+  def main(args : Array[String]) {
+
+		//  Prepare our context and sockets
+		val context = ZMQ.context(1)
+
+		//  Socket facing clients
+		val frontend = context.socket(ZMQ.ROUTER)
+		frontend.bind("tcp://*:5559")
+
+		//  Socket facing services
+		val backend = context.socket(ZMQ.DEALER)
+		backend.bind("tcp://*:5560")
+
+		//  Start built-in device
+		val queue = new ZMQQueue(context, frontend, backend)
+		// have fun!
+
+		//  We never get here but clean up anyhow
+		frontend close
+
+		backend close
+
+		context term
+	}
+}

--- a/examples/scala/MultiThreadedRelay.scala
+++ b/examples/scala/MultiThreadedRelay.scala
@@ -1,0 +1,48 @@
+/*
+ *  Multithreaded relay in Scala
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+ */
+
+import org.zeromq.ZMQ
+
+object mtRelay {
+  def main(args : Array[String]) {
+		val context = ZMQ.context(1)
+
+		//  Bind to inproc: endpoint, then start upstream thread
+		val receiver = context.socket(ZMQ.PAIR)
+		receiver.bind("inproc://step3")
+		//  Step 2 relays the signal to step 3
+		new Thread {
+  		// val context1 = ZMQ.context(1)
+			try {
+				//  Bind to inproc: endpoint, then start upstream thread
+				// println(context1)
+			} catch {
+				case e => e.printStackTrace()
+			}
+			// val receiver = context.socket(ZMQ.PAIR)
+			receiver.bind("inproc://step2")
+			new Thread{
+				//  Signal downstream to step 2
+				val sender = context.socket(ZMQ.PAIR)
+				sender.connect("inproc://step2")
+				sender.send("".getBytes(),0)
+			}
+
+			//  Wait for signal
+			val message=receiver.recv(0)
+			Thread.sleep (1000)
+			//  Signal downstream to step 3
+			val sender = context.socket(ZMQ.PAIR)
+			sender.connect("inproc://step3")
+			sender.send(message,0)
+		}
+
+		//  Wait for signal
+		val message = receiver.recv(0)
+		println ("Test successful!")
+	}
+}

--- a/examples/scala/SyncPub.scala
+++ b/examples/scala/SyncPub.scala
@@ -1,0 +1,58 @@
+/*
+ *
+ * Synchronized publisher.
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+ */
+
+import org.zeromq.ZMQ
+import org.zeromq.ZMQ.Context
+import org.zeromq.ZMQ.Socket
+
+object SyncPub {
+  def main(args : Array[String]) {
+		/**
+		 * We wait for 10 subscribers
+		 */
+		val SUBSCRIBERS_EXPECTED = 10
+
+		val context = ZMQ.context(1)
+
+		//  Socket to talk to clients
+		val publisher = context.socket(ZMQ.PUB)
+		publisher.bind("tcp://*:5561")
+
+		//  Socket to receive signals
+		val syncservice = context.socket(ZMQ.REP)
+		syncservice.bind("tcp://*:5562")
+
+		//  Get synchronization from subscribers
+		for (subscribers <- 1 to SUBSCRIBERS_EXPECTED) {
+			//  - wait for synchronization request
+			var value = syncservice.recv(0)
+
+			//  - send synchronization reply
+			syncservice.send("".getBytes(), 0)
+		}
+		//  Now broadcast exactly 1M updates followed by END
+		for (update_nbr <- 1 to 1000000){
+			publisher.send("Rhubarb".getBytes(), 0)
+		}
+
+		publisher.send("END".getBytes(), 0)
+
+		//  Give 0MQ/2.0.x time to flush output
+
+		try {
+			Thread.sleep (1000)
+		} catch  {
+			case e: InterruptedException => e.printStackTrace()
+		}
+
+		// clean up
+		publisher.close()
+		syncservice.close()
+		context.term()
+	}
+}

--- a/examples/scala/SyncSub.scala
+++ b/examples/scala/SyncSub.scala
@@ -1,0 +1,45 @@
+/*
+ * Synchronized subscriber
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+ */
+
+import org.zeromq.ZMQ
+import org.zeromq.ZMQ.Context
+import org.zeromq.ZMQ.Socket
+
+object SyncSub {
+  def main(args : Array[String]) {
+		val context = ZMQ.context(1)
+
+		//  First, connect our subscriber socket
+		val subscriber = context.socket(ZMQ.SUB)
+		subscriber.connect("tcp://localhost:5561")
+		subscriber.subscribe("".getBytes())
+
+		//  Second, synchronize with publisher
+		val syncclient = context.socket(ZMQ.REQ)
+		subscriber.connect("tcp://localhost:5562")
+
+		//  - send a synchronization request
+		syncclient.send("".getBytes(), 0)
+
+		//  - wait for synchronization reply
+		val value = syncclient.recv(0)
+
+		//  Third, get our updates and report how many we got
+		var update_nbr = 0
+		var string = ""
+		do {
+			var stringValue = subscriber.recv(0)
+			string  = new String(stringValue)
+			update_nbr = update_nbr + 1
+		} while (string != "END")
+		println("Received "+update_nbr+" updates.")
+
+		subscriber.close()
+		syncclient.close()
+		context.term()
+	}
+}

--- a/examples/scala/ZMsg.scala
+++ b/examples/scala/ZMsg.scala
@@ -1,0 +1,70 @@
+/*
+ * Multipart message class for example applications.
+ *
+ * @Author:     Giovanni Ruggiero
+ * @Email:      giovanni.ruggiero@gmail.com
+*/
+
+import org.zeromq.ZMQ.Socket
+import org.zeromq.ZMQ
+import ZHelpers._
+
+class ZMsg {
+	type ZMsg = scala.collection.mutable.ListBuffer[Array[Byte]]
+	private val msgParts = scala.collection.mutable.ListBuffer[Array[Byte]]()
+
+	private val Noflags = 0
+
+	def this(body: String) = { this(); msgParts += body.getBytes}
+
+	def this(body: Array[Byte]) = this(new String(body))
+
+	def this(socket: Socket) = {this(); recv(socket)}
+
+	def body = msgParts last
+
+	def body(bodyStr: String) = msgParts.update(msgParts.length -1,bodyStr.getBytes)
+
+
+	def address = msgParts head
+
+	def addressToString = new String(msgParts head)
+
+	def address(address:String) = {
+		msgParts remove 0
+		address.getBytes +: msgParts
+	}
+
+	def recv(socket: Socket) =  for (frame <- socket.recvAll(0)) msgParts += frame
+
+	def send(socket: Socket) = {
+		val last = msgParts last
+
+		for (frame <- msgParts if frame != last) {
+			socket.send(frame,ZMQ.SNDMORE)
+		}
+		socket.send(last,Noflags)
+	}
+
+	def length = msgParts.length
+
+	def stringToBody(bodyStr: String) = body(bodyStr)
+
+	def bodyToString = new String(body)
+
+	def wrap(address:Array[Byte]) = {
+		Array[Byte]() +: msgParts
+		address +: msgParts
+	}
+
+	def unwrap() = {
+		val address = msgParts remove 0
+
+		msgParts remove 0
+
+		address
+	}
+
+	override def toString = msgParts.mkString("|","|","|")
+
+}

--- a/examples/scala/asyncsrv.scala
+++ b/examples/scala/asyncsrv.scala
@@ -1,0 +1,128 @@
+/*
+ *  Asynchronous client-to-server (DEALER to BROKER)
+ *
+ *  While this example runs in a single process, that is just to make
+ *  it easier to start and stop the example. Each task has its own
+ *  context and conceptually acts as a separate process.
+ *
+ *  @Author:     Giovanni Ruggiero
+ *  @Email:      giovanni.ruggiero@gmail.com
+*/
+
+import org.zeromq.ZMQ
+import ZHelpers._
+
+object asyncsrv  {
+  //  ---------------------------------------------------------------------
+  //  This is our client task
+  //  It connects to the server, and then sends a request once per second
+  //  It collects responses as they arrive, and it prints them out. We will
+  //  run several client tasks in parallel, each with a different random ID.
+	class ClientTask() extends Runnable {
+		def run() {
+			val ctx = ZMQ.context(1)
+			val client = ctx.socket(ZMQ.DEALER)
+      //  Generate printable identity for the client
+			setID(client);
+      val identity = new String(client getIdentity)
+			// println(identity)
+      client.connect("tcp://localhost:5570")
+			val poller = ctx.poller(1)
+
+			poller.register(client,ZMQ.Poller.POLLIN)
+			var requestNbr = 0
+			while (true) {
+        //  Tick once per second, pulling in arriving messages
+				for (centitick <- 1 to 100) {
+					poller.poll(10000)
+					if(poller.pollin(0)) {
+						val msg = new ZMsg(client)
+						printf("%s : %s\n", identity, msg.bodyToString)
+					}
+				}
+				requestNbr += 1
+				val msg = new ZMsg("request: %d" format requestNbr)
+				client.sendMsg(msg)
+			}
+		}
+	}
+  //  ---------------------------------------------------------------------
+  //  This is our server task
+  //  It uses the multithreaded server model to deal requests out to a pool
+  //  of workers and route replies back to clients. One worker can handle
+  //  one request at a time but one client can talk to multiple workers at
+  //  once.
+	class ServerTask() extends Runnable {
+		def run() {
+			val Nworkers = 5
+			val ctx = ZMQ.context(1)
+			val frontend = ctx.socket(ZMQ.ROUTER)
+			val backend = ctx.socket(ZMQ.DEALER)
+			//  Frontend socket talks to clients over TCP
+      frontend.bind("tcp://*:5570");
+      //  Backend socket talks to workers over inproc
+      backend.bind("inproc://backend");
+      //  Launch pool of worker threads, precise number is not critical
+			val workers = List.fill(Nworkers)(new Thread(new ServerWorker(ctx)))
+			workers foreach (_.start)
+
+      //  Connect backend to frontend via a queue device
+      //  We could do this:
+      //      zmq_device (ZMQ_QUEUE, frontend, backend);
+      //  But doing it ourselves means we can debug this more easily
+
+      //  Switch messages between frontend and backend
+			val sockets = List(frontend,backend)
+			val poller = ctx.poller(2)
+
+			poller.register(frontend,ZMQ.Poller.POLLIN)
+			poller.register(backend,ZMQ.Poller.POLLIN)
+
+			while (true) {
+				poller.poll
+				if (poller.pollin(0)) {
+					val msg = new ZMsg(frontend)
+					println("Request from client: " + msg)
+					backend.sendMsg(msg)
+				}
+				if (poller.pollin(1)) {
+					val msg = new ZMsg(backend)
+					println("Reply from worker: " + msg)
+					frontend.sendMsg(msg)
+				}
+			}
+
+		}
+	}
+
+  //  Accept a request and reply with the same text a random number of
+  //  times, with random delays between replies.
+  //
+	class ServerWorker(ctx: ZMQ.Context) extends Runnable {
+		def run() {
+			val rand = new java.util.Random(System.currentTimeMillis)
+			val worker = ctx.socket(ZMQ.DEALER)
+      worker.connect("inproc://backend")
+      while (true) {
+        //  The DEALER socket gives us the address envelope and message
+        val zmsg = new ZMsg(worker);
+        //  Send 0..4 replies back
+        val replies = rand.nextInt(5);
+				for (reply <- 1 to replies) {
+					Thread.sleep (rand.nextInt(1) * 1000)
+					worker.sendMsg(zmsg)
+				}
+			}
+		}
+	}
+
+  //  This main thread simply starts several clients, and a server, and then
+  //  waits for the server to finish.
+  //
+  def main(args : Array[String]) {
+		val Nclients = 3
+		val clients = List.fill(Nclients)(new Thread(new ClientTask()))
+		clients foreach (_.start)
+		new Thread(new ServerTask()).start
+	}
+}

--- a/examples/scala/durapub.scala
+++ b/examples/scala/durapub.scala
@@ -1,0 +1,37 @@
+/*
+ * Publisher for durable subscriber
+ *
+ *  @author Giovanni Ruggiero
+ *  @email giovanni.ruggiero@gmail.com
+ *
+ */
+
+import org.zeromq.ZMQ
+
+object durapub {
+  def main(args : Array[String]) {
+
+		val context = ZMQ.context(1)
+		val publisher = context.socket(ZMQ.PUB)
+
+		// Subscriber tells us when it's ready here
+		val sync = context.socket(ZMQ.PULL)
+
+		sync.bind("tcp://*:5564")
+
+		// We send updates via this socket
+		publisher.bind("tcp://*:5565")
+		publisher setHWM 2
+		// Wait for synchronization request
+		sync recv 0
+
+		// Now broadcast exactly 10 updates with pause
+		for (i <- 1 to 10) {
+			val msg = String.format("Update %d", i: Integer)
+			publisher.send(msg.getBytes(), 0)
+			Thread sleep 1000
+		}
+		publisher.send("END".getBytes(), 0)
+		Thread sleep 1000 // Give 0MQ/2.0.x to flush output
+	}
+}

--- a/examples/scala/durapub2.scala
+++ b/examples/scala/durapub2.scala
@@ -1,0 +1,40 @@
+/*
+ *  @author Giovanni Ruggiero
+ *  @email giovanni.ruggiero@gmail.com
+ */
+
+import org.zeromq.ZMQ
+
+object durapub2 {
+  def main(args : Array[String]) {
+
+		val context = ZMQ.context(1)
+		val sync = context.socket(ZMQ.PULL)
+		val publisher = context.socket(ZMQ.PUB)
+
+		// Subscriber tells us when it's ready
+		sync.bind("tcp://*:5564")
+
+		// We send updates via this socket
+		publisher.bind("tcp://*:5565")
+
+		// Prevent publisher overflow from slow subscribers
+		publisher.setHWM(1)
+
+		// Specify swap space in bytes, this covers all subscribers
+		publisher.setSwap(25000000)
+
+		// Wait for synchronization request
+		sync.recv(0)
+
+		// Now broadcast exactly 10 updates with pause
+		for (i <- 1 to 10) {
+			val msg = String.format("Update %d", i: Integer)
+			publisher.send(msg.getBytes(), 0)
+			Thread sleep 1000
+		}
+		publisher.send("END".getBytes(), 0)
+		Thread.sleep(1000) // Give 0MQ/2.0.x time to flush output
+	}
+}
+

--- a/examples/scala/durasub.scala
+++ b/examples/scala/durasub.scala
@@ -1,0 +1,35 @@
+/*
+ * Durable subscriber
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+ *
+ */
+
+import org.zeromq.ZMQ
+
+object durasub {
+  def main(args : Array[String]) {
+
+		val context = ZMQ.context(1)
+
+		// Connect our subscriber socket
+		val subscriber = context.socket(ZMQ.SUB)
+
+		// Synchronize with the publisher
+		val sync = context.socket(ZMQ.PUSH)
+
+		subscriber.setIdentity("Hello".getBytes)
+		subscriber.subscribe("".getBytes)
+		subscriber.connect("tcp://localhost:5565")
+		sync.connect("tcp://localhost:5564")
+		sync.send("".getBytes, 0)
+
+		// Get updates, expect random Ctrl-C death
+		var msg = ""
+	  do {
+			msg = new String(subscriber.recv(0))
+			println(msg)
+		} while (!msg.equalsIgnoreCase("END"))
+	}
+}

--- a/examples/scala/hwclient.scala
+++ b/examples/scala/hwclient.scala
@@ -1,0 +1,41 @@
+/*
+ *
+ *  Hello World client in Scala
+ *  Connects REQ socket to tcp://localhost:5555
+ *  Sends "Hello" to server, expects "World" back
+ *
+ *  @author Giovanni Ruggiero
+ *  @email giovanni.ruggiero@gmail.com
+*/
+
+import org.zeromq.ZMQ
+import org.zeromq.ZMQ.{Context,Socket}
+
+object HelloWorldClient{
+  def main(args : Array[String]) {
+    //  Prepare our context and socket
+    val context = ZMQ.context(1)
+    val socket = context.socket(ZMQ.REQ)
+
+    println("Connecting to hello world server...")
+    socket.connect ("tcp://localhost:5555")
+
+    //  Do 10 requests, waiting each time for a response
+		for (request_nbr <- 1 to 10)  {
+      //  Create a "Hello" message.
+      //  Ensure that the last byte of our "Hello" message is 0 because
+      //  our "Hello World" server is expecting a 0-terminated string:
+			val request = "Hello ".getBytes()
+      request(request.length-1)=0 //Sets the last byte to 0
+      // Send the message
+      println("Sending request " + request_nbr + "...") + request.toString
+      socket.send(request, 0)
+
+      //  Get the reply.
+      val reply = socket.recv(0)
+      //  When displaying reply as a String, omit the last byte because
+      //  our "Hello World" server has sent us a 0-terminated string:
+      println("Received reply " + request_nbr + ": [" + new String(reply,0,reply.length-1) + "]")
+    }
+  }
+}

--- a/examples/scala/hwserver.scala
+++ b/examples/scala/hwserver.scala
@@ -1,0 +1,48 @@
+//
+//  Hello World server in Scala
+//  Binds REP socket to tcp://*:5555
+//  Expects "Hello" from client, replies with "World"
+//
+//  author Giovanni Ruggiero
+//  email giovanni.ruggiero@gmail.com
+//
+//
+
+import org.zeromq.ZMQ
+import org.zeromq.ZMQ.{Context,Socket}
+
+object HelloWorldServer {
+  def main(args : Array[String]) {
+    //  Prepare our context and socket
+    val context = ZMQ.context(1)
+    val socket = context.socket(ZMQ.REP)
+		println ("starting")
+    socket.bind ("tcp://*:5555")
+
+    while (true) {
+      //  Wait for next request from client
+      //  We will wait for a 0-terminated string (C string) from the client,
+      //  so that this server also works with The Guide's C and C++ "Hello World" clients
+      val request = socket.recv (0)
+      //  In order to display the 0-terminated string as a String,
+      //  we omit the last byte from request
+      println ("Received request: ["
+							 + new String(request,0,request.length-1)  //  Creates a String from request, minus the last byte
+							 + "]")
+
+      //  Do some 'work'
+      try {
+        Thread.sleep (1000)
+      } catch  {
+        case e: InterruptedException => e.printStackTrace()
+      }
+
+      //  Send reply back to client
+      //  We will send a 0-terminated string (C string) back to the client,
+      //  so that this server also works with The Guide's C and C++ "Hello World" clients
+      val reply = "World ".getBytes
+      reply(reply.length-1)=0 //Sets the last byte of the reply to 0
+      socket.send(reply, 0)
+    }
+  }
+}

--- a/examples/scala/identity.scala
+++ b/examples/scala/identity.scala
@@ -1,0 +1,29 @@
+// Demonstrate identities as used by the request-reply pattern.
+//
+// @author Giovanni Ruggiero
+// @email giovanni.ruggiero@gmail.com
+
+import org.zeromq.ZMQ
+import ZHelpers._
+
+object identity {
+  def main(args : Array[String]) {
+		val context = ZMQ.context(1)
+
+		val sink = context.socket(ZMQ.DEALER)
+		sink.bind("inproc://example")
+
+		val anonymous = context.socket(ZMQ.REQ)
+		anonymous.connect("inproc://example")
+		anonymous.send("ROUTER uses a generated UUID".getBytes,0)
+		dump(sink)
+
+		val identified = context.socket(ZMQ.REQ)
+		identified.setIdentity("Hello" getBytes)
+		identified.connect("inproc://example")
+		identified.send("ROUTER socket uses REQ's socket identity".getBytes,0)
+		dump(sink)
+
+		identified.close
+	}
+}

--- a/examples/scala/lrubroker.scala
+++ b/examples/scala/lrubroker.scala
@@ -1,0 +1,134 @@
+/*
+ *  Least-recently used (LRU) queue device
+ *  Clients and workers are shown here in-process
+ *
+ *  While this example runs in a single process, that is just to make
+ *  it easier to start and stop the example. Each thread has its own
+ *  context and conceptually acts as a separate process.
+ *
+ *
+ *  Author:     Giovanni Ruggiero
+ *  Email:      giovanni.ruggiero@gmail.com
+ */
+
+import org.zeromq.ZMQ
+import ZHelpers._
+
+object lrubroker  {
+  def main(args : Array[String]) {
+		val NOFLAGS = 0
+
+		//  Basic request-reply client using REQ socket
+		//
+		class ClientTask() extends Runnable {
+			def run() {
+				val ctx = ZMQ.context(1)
+				val client = ctx.socket(ZMQ.REQ)
+				setID(client);
+				client.connect("tcp://localhost:5555");
+
+				//  Send request, get reply
+				client.send("HELLO ".getBytes, NOFLAGS);
+				val reply = client.recv(NOFLAGS);
+				printf("Client: %s\n", reply);
+			}
+		}
+
+		//  Worker using REQ socket to do LRU routing
+		//
+		class WorkerTask() extends Runnable {
+			def run() {
+				println("worker started")
+				Thread.sleep(1000)
+				val ctx = ZMQ.context(1)
+				val worker = ctx.socket(ZMQ.REQ)
+				setID(worker);
+				worker.connect("tcp://localhost:5556");
+				//  Tell broker we're ready for work
+				worker.send("READY".getBytes, NOFLAGS);
+				while (true) {
+					//  Read and save all frames until we get an empty frame
+					//  In this example there is only 1 but it could be more
+					val address = worker.recv(NOFLAGS);
+					val empty = worker.recv(NOFLAGS);
+
+					//  Get request, send reply
+					val request = worker.recv(NOFLAGS);
+					printf("Worker: %s\n", request);
+
+					worker.send(address, ZMQ.SNDMORE);
+					worker.send("".getBytes, ZMQ.SNDMORE);
+					worker.send("OK".getBytes, NOFLAGS);
+				}
+			}
+		}
+
+		val NBR_CLIENTS = 10;
+		val NBR_WORKERS = 3;
+
+		//  Prepare our context and sockets
+		val ctx = ZMQ.context(1)
+		val frontend = ctx.socket(ZMQ.ROUTER)
+		val backend = ctx.socket(ZMQ.ROUTER)
+
+		frontend.bind("tcp://*:5555")
+		backend.bind("tcp://*:5556")
+
+		//  Logic of LRU loop
+		//  - Poll backend always, frontend only if 1+ worker ready
+		//  - If worker replies, queue worker as ready and forward reply
+		//    to client if necessary
+		//  - If client requests, pop next worker and send request to it
+		val workerQueue = scala.collection.immutable.Queue[String]()
+		var available_workers = 0
+
+		val poller = ctx.poller(2)
+
+		// Always poll for worker activity on backend
+		poller.register(backend,ZMQ.Poller.POLLIN)
+
+		// Poll front-end only if we have available workers
+		poller.register(frontend,ZMQ.Poller.POLLIN)
+		poller.poll(1000)
+
+		var clientNbr = NBR_CLIENTS
+		while (true) {
+			val ret = poller.poll()
+			println(ret)
+
+			if(poller.pollin(0) && clientNbr > 0) {
+				val workerAddr = backend.recv(NOFLAGS)
+				assert (available_workers < NBR_WORKERS)
+				available_workers += 1
+				//  Queue worker address for LRU routing
+				workerQueue.enqueue(workerAddr)
+				//  Second frame is empty
+				var empty = backend.recv(NOFLAGS)
+				assert (empty == "".getBytes)
+				//  Third frame is READY or else a client reply address
+				val clientAddr = backend.recv(NOFLAGS)
+				if (!clientAddr.equals("READY")) {
+					empty = backend.recv(NOFLAGS);
+					val reply = backend.recv(NOFLAGS);
+					frontend.send(clientAddr, ZMQ.SNDMORE)
+					frontend.send("".getBytes, ZMQ.SNDMORE)
+					frontend.send(reply, NOFLAGS)
+					clientNbr -=1 //  Exit after N messages
+				}
+			}
+			if(available_workers > 0 && poller.pollin(1)) {
+				//  Now get next client request, route to LRU worker
+				//  Client request is [address][empty][request]
+				val clientAddr = frontend.recv(NOFLAGS);
+				val empty = frontend.recv(NOFLAGS);
+				val request = frontend.recv(NOFLAGS);
+
+				backend.send(workerQueue.dequeue._1.getBytes, ZMQ.SNDMORE)
+				backend.send("".getBytes, ZMQ.SNDMORE)
+				backend.send(clientAddr, ZMQ.SNDMORE)
+				backend.send("".getBytes, ZMQ.SNDMORE)
+				backend.send(request, NOFLAGS);
+			}
+		}
+	}
+}

--- a/examples/scala/lruqueue.scala
+++ b/examples/scala/lruqueue.scala
@@ -1,0 +1,142 @@
+/*
+ *  Least-recently used (LRU) queue device
+ *  Clients and workers are shown here in-process
+ *
+ *  While this example runs in a single process, that is just to make
+ *  it easier to start and stop the example. Each thread has its own
+ *  context and conceptually acts as a separate process.
+ *
+ *
+ *  Author:     Giovanni Ruggiero
+ *  Email:      giovanni.ruggiero@gmail.com
+*/
+
+import org.zeromq.ZMQ
+import ZHelpers._
+
+//  Basic request-reply client using REQ socket
+//
+class ClientTask() extends Runnable {
+	def run() {
+		val ctx = ZMQ.context(1)
+		val client = ctx.socket(ZMQ.REQ)
+		setID(client)
+		client.connect("tcp://localhost:5555")
+
+		//  Send request, get reply
+		client.send("HELLO".getBytes, 0)
+		val reply = client.recv(0)
+		printf("Client: %s\n", new String(reply))
+	}
+}
+
+//  Worker using REQ socket to do LRU routing
+//
+class WorkerTask() extends Runnable {
+	def run() {
+		// println("worker started")
+		// Thread.sleep(1000)
+		val ctx = ZMQ.context(1)
+		val worker = ctx.socket(ZMQ.REQ)
+		setID(worker)
+		worker.connect("tcp://localhost:5556")
+		//  Tell broker we're ready for work
+		worker.send("READY".getBytes, 0)
+		while (true) {
+			//  Read and save all frames until we get an empty frame
+			//  In this example there is only 1 but it could be more
+			val address = worker.recv(0)
+			val empty = worker.recv(0)
+
+			//  Get request, send reply
+			val request = worker.recv(0)
+			printf("Worker: %s\n", new String(request))
+
+			worker.send(address, ZMQ.SNDMORE)
+			worker.send("".getBytes, ZMQ.SNDMORE)
+			worker.send("OK".getBytes, 0)
+		}
+	}
+}
+
+object lruqueue   {
+  def main(args : Array[String]) {
+		val NOFLAGS = 0
+
+		//  Worker using REQ socket to do LRU routing
+		//
+		val NBR_CLIENTS = 10
+		val NBR_WORKERS = 3
+
+		//  Prepare our context and sockets
+		val ctx = ZMQ.context(1)
+		val frontend = ctx.socket(ZMQ.ROUTER)
+		val backend = ctx.socket(ZMQ.ROUTER)
+
+		frontend.bind("tcp://*:5555")
+		backend.bind("tcp://*:5556")
+
+		val clients = List.fill(NBR_CLIENTS)(new Thread(new ClientTask))
+		clients foreach (_.start)
+
+		val workers = List.fill(NBR_WORKERS)(new Thread(new WorkerTask))
+		workers foreach (_.start)
+
+		//  Logic of LRU loop
+		//  - Poll backend always, frontend only if 1+ worker ready
+		//  - If worker replies, queue worker as ready and forward reply
+		//    to client if necessary
+		//  - If client requests, pop next worker and send request to it
+		val workerQueue = scala.collection.mutable.Queue[Array[Byte]]()
+		var availableWorkers = 0
+
+		val poller = ctx.poller(2)
+
+		// Always poll for worker activity on backend
+		poller.register(backend,ZMQ.Poller.POLLIN)
+
+		// Poll front-end only if we have available workers
+		poller.register(frontend,ZMQ.Poller.POLLIN)
+
+		var clientNbr = NBR_CLIENTS
+		while (true) {
+			poller.poll
+
+			if(poller.pollin(0) && clientNbr > 0) {
+				val workerAddr = backend.recv(NOFLAGS)
+				assert (availableWorkers < NBR_WORKERS)
+				availableWorkers += 1
+
+				//  Queue worker address for LRU routing
+				workerQueue.enqueue(workerAddr)
+				//  Second frame is empty
+				var empty = backend.recv(NOFLAGS)
+				assert(new String(empty) == "")
+				//  Third frame is READY or else a client reply address
+				val clientAddr = backend.recv(NOFLAGS)
+				if (!new String(clientAddr).equals("READY")) {
+					val reply = backend.recv(NOFLAGS)
+					frontend.send(clientAddr, ZMQ.SNDMORE)
+					frontend.send("".getBytes, ZMQ.SNDMORE)
+					frontend.send(reply, NOFLAGS)
+					clientNbr -=1 //  Exit after N messages
+				}
+			}
+			if(availableWorkers > 0 && poller.pollin(1)) {
+				//  Now get next client request, route to LRU worker
+				//  Client request is [address][empty][request]
+				val clientAddr = frontend.recv(NOFLAGS)
+				val empty = frontend.recv(NOFLAGS)
+				val request = frontend.recv(NOFLAGS)
+
+				backend.send(workerQueue.dequeue, ZMQ.SNDMORE)
+				backend.send("".getBytes, ZMQ.SNDMORE)
+				backend.send(clientAddr, ZMQ.SNDMORE)
+				backend.send("".getBytes, ZMQ.SNDMORE)
+				backend.send(request, NOFLAGS)
+				availableWorkers -= 1
+			}
+
+		}
+	}
+}

--- a/examples/scala/lruqueue2.scala
+++ b/examples/scala/lruqueue2.scala
@@ -1,0 +1,123 @@
+/*
+ *  Least-recently used (LRU) queue device
+ *  Clients and workers are shown here in-process
+ *
+ *  While this example runs in a single process, that is just to make
+ *  it easier to start and stop the example. Each thread has its own
+ *  context and conceptually acts as a separate process.
+ *
+ *
+ * @Author:     Giovanni Ruggiero
+ * @Email:      giovanni.ruggiero@gmail.com
+*/
+
+import org.zeromq.ZMQ
+import ZHelpers._
+
+object lruqueue2OK   {
+//  Basic request-reply client using REQ socket
+//
+class ClientTask() extends Runnable {
+	def run() {
+		val ctx = ZMQ.context(1)
+		val client = ctx.socket(ZMQ.REQ)
+		setID(client);
+		client.connect("tcp://localhost:5555");
+
+		//  Send request, get reply
+		client.send("HELLO".getBytes, 0);
+		val reply = client.recv(0);
+		printf("Client: %s\n", new String(reply));
+	}
+}
+
+//  Worker using REQ socket to do LRU routing
+//
+class WorkerTask() extends Runnable {
+	def run() {
+		val ctx = ZMQ.context(1)
+		val worker = ctx.socket(ZMQ.REQ)
+		setID(worker);
+		worker.connect("tcp://localhost:5556");
+		//  Tell broker we're ready for work
+		worker.send("READY".getBytes, 0);
+		while (true) {
+			//  Read and save all frames until we get an empty frame
+			//  In this example there is only 1 but it could be more
+			val msg = new ZMsg(worker)
+			printf("Worker: %s\n", msg.bodyToString);
+			msg.stringToBody("OK")
+			msg.send(worker)
+		}
+	}
+}
+
+  def main(args : Array[String]) {
+		val NOFLAGS = 0
+
+		//  Worker using REQ socket to do LRU routing
+		//
+		val NBR_CLIENTS = 10;
+		val NBR_WORKERS = 3;
+
+		//  Prepare our context and sockets
+		val ctx = ZMQ.context(1)
+		val frontend = ctx.socket(ZMQ.ROUTER)
+		val backend = ctx.socket(ZMQ.ROUTER)
+
+		frontend.bind("tcp://*:5555")
+		backend.bind("tcp://*:5556")
+
+		val clients = List.fill(NBR_CLIENTS)(new Thread(new ClientTask))
+		clients foreach (_.start)
+
+		val workers = List.fill(NBR_WORKERS)(new Thread(new WorkerTask))
+		workers foreach (_.start)
+
+		//  Logic of LRU loop
+		//  - Poll backend always, frontend only if 1+ worker ready
+		//  - If worker replies, queue worker as ready and forward reply
+		//    to client if necessary
+		//  - If client requests, pop next worker and send request to it
+		val workerQueue = scala.collection.mutable.Queue[Array[Byte]]()
+		var availableWorkers = 0
+
+		val poller = ctx.poller(2)
+
+		// Always poll for worker activity on backend
+		poller.register(backend,ZMQ.Poller.POLLIN)
+
+		// Poll front-end only if we have available workers
+		poller.register(frontend,ZMQ.Poller.POLLIN)
+
+		var clientNbr = NBR_CLIENTS
+		while (true) {
+			poller.poll
+
+			if(poller.pollin(0) && clientNbr > 0) {
+				val msg = new ZMsg(backend)
+				val workerAddr = msg.unwrap
+
+				assert (availableWorkers < NBR_WORKERS)
+				availableWorkers += 1
+
+				//  Queue worker address for LRU routing
+				workerQueue.enqueue(workerAddr)
+				//  Address is READY or else a client reply address
+				val clientAddr = msg.address
+				if (!new String(clientAddr).equals("READY")) {
+					frontend.sendMsg(msg)
+					clientNbr -=1 //  Exit after N messages
+				}
+			}
+			if(availableWorkers > 0 && poller.pollin(1)) {
+ 				//  Now get next client request, route to LRU worker
+				//  Client request is [address][empty][request]
+				val msg = new ZMsg(frontend)
+				msg.wrap(workerQueue.dequeue)
+				backend.sendMsg(msg)
+				availableWorkers -= 1
+			}
+		}
+	}
+}

--- a/examples/scala/mspoller.scala
+++ b/examples/scala/mspoller.scala
@@ -1,0 +1,43 @@
+/*
+ *  Reading from multiple sockets in Scala
+ *  This version uses ZMQ.Poller
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+ */
+
+import org.zeromq.ZMQ
+
+object mspoller {
+  def main(args : Array[String]) {
+
+		val context = ZMQ.context(1)
+
+		// Connect to task ventilator
+		val receiver = context.socket(ZMQ.PULL)
+		receiver.connect("tcp://localhost:5557")
+
+		//  Connect to weather server
+		val subscriber = context.socket(ZMQ.SUB)
+		subscriber.connect("tcp://localhost:5556")
+		subscriber.subscribe("10001 ".getBytes())
+
+		//  Initialize poll set
+		val items = context.poller(2)
+		items.register(receiver, 0)
+		items.register(subscriber, 0)
+
+		//  Process messages from both sockets
+		while (true) {
+			items.poll()
+			if (items.pollin(0)) {
+				val message0 = receiver.recv(0)
+				//  Process task
+			}
+			if (items.pollin(1)) {
+				val message1 = subscriber.recv(0)
+				//  Process weather update
+			}
+		}
+	}
+}

--- a/examples/scala/msreader.scala
+++ b/examples/scala/msreader.scala
@@ -1,0 +1,44 @@
+/*
+ *
+ *  Reading from multiple sockets in Scala
+ *  This version uses a simple recv loop
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+ */
+
+import org.zeromq.ZMQ
+
+object msreader {
+  def main(args : Array[String]) {
+
+		//  Prepare our context and sockets
+		val context = ZMQ.context(1)
+
+		// Connect to task ventilator
+		val receiver = context.socket(ZMQ.PULL)
+		receiver.connect("tcp://localhost:5557")
+
+		//  Connect to weather server
+		val subscriber = context.socket(ZMQ.SUB)
+		subscriber.connect("tcp://localhost:5556")
+		subscriber.subscribe("10001 ".getBytes())
+
+		//  Process messages from both sockets
+		//  We prioritize traffic from the task ventilator
+		while (true) {
+			//  Process any waiting tasks
+			val task = receiver.recv(ZMQ.NOBLOCK)
+			while(task != null) {
+				//  process task
+			}
+			//  Process any waiting weather updates
+			val update = subscriber.recv(ZMQ.NOBLOCK)
+			while (update != null) {
+				//  process weather update
+			}
+			//  No activity, so sleep for 1 msec
+			Thread.sleep(1)
+		}
+	}
+}

--- a/examples/scala/mtserver.scala
+++ b/examples/scala/mtserver.scala
@@ -1,0 +1,54 @@
+/*
+ *  Multithreaded Hello World server in Scala
+ *
+ *  @author Giovanni Ruggiero
+ *  @email giovanni.ruggiero@gmail.com
+ *
+ */
+
+import org.zeromq.ZMQ
+import org.zeromq.ZMQQueue
+import org.zeromq.ZMQ.{Context,Socket}
+import ZHelpers._
+
+object mtserver {
+  def main(args : Array[String]) {
+		val context = ZMQ.context(1)
+		val clients = context.socket(ZMQ.ROUTER)
+		clients.bind ("tcp://*:5555")
+		val workers = context.socket(ZMQ.DEALER)
+		workers.bind ("inproc://workers")
+
+		//  Launch pool of worker threads
+		for (thread_nbr <- 1 to 5)  {
+			val worker_routine = new Thread(){
+				override def run(){
+					val socket = context.socket(ZMQ.REP)
+					socket.connect ("inproc://workers")
+
+					while (true) {
+						//  Wait for next request from client (C string)
+						val request = socket.recv (0)
+						println ("Received request: ["+new String(request,0,request.length-1)+"]")
+
+						//  Do some 'work'
+						try {
+							Thread.sleep (1000)
+						} catch  {
+							case e: InterruptedException => e.printStackTrace()
+						}
+
+						//  Send reply back to client (C string)
+						val reply = "World ".getBytes
+						reply(reply.length-1)=0 //Sets the last byte of the reply to 0
+						socket.send(reply, 0)
+					}
+				}
+			}
+			worker_routine.start()
+		}
+		//  Connect work threads to client threads via a queue
+		val zMQQueue = new ZMQQueue(context,clients, workers)
+		zMQQueue run
+	}
+}

--- a/examples/scala/peering1.scala
+++ b/examples/scala/peering1.scala
@@ -1,0 +1,59 @@
+/*
+ *  Broker peering simulation (part 1)
+ *  Prototypes the state flow
+ *
+ *
+ *  @Author:     Giovanni Ruggiero
+ *  @Email:      giovanni.ruggiero@gmail.com
+*/
+
+import org.zeromq.ZMQ
+import ZHelpers._
+import ClusterDns._
+
+object peering1 {
+	val Statefe = "statefe"
+	val Statebe = "statebe"
+
+  def main(args : Array[String]) {
+    //  First argument is this broker's name
+    //  Other arguments are our peers' names
+    //
+    if (args.length < 2) {
+        println ("syntax: peering1 me {you}...")
+        exit()
+    }
+    val self = args(0)
+		implicit val dns = clusterDns
+		implicit val host = self
+    printf ("I: preparing broker at %s...\n", self);
+
+		val rand = new java.util.Random(System.currentTimeMillis)
+		val ctx = ZMQ.context(1)
+		val statebe = ctx.socket(ZMQ.PUB)
+		statebe.dnsBind(Statebe)
+		val statefe = ctx.socket(ZMQ.SUB)
+		statefe.subscribe("".getBytes)
+
+		for (cluster <- (1 until args.length)) {
+			printf ("I: connecting to state backend at '%s'\n", args(cluster))
+			statefe.dnsConnect(args(cluster),Statefe)
+		}
+    //  Send out status messages to peers, and collect from peers
+    //  The zmq_poll timeout defines our own heartbeating
+		while (true) {
+			val poller = ctx.poller(1)
+			poller.register(statefe,ZMQ.Poller.POLLIN)
+			poller.poll(1000000)
+			if(poller.pollin(0)) {
+				val msg = new ZMsg(statefe)
+        printf ("%s - %s workers free\n", msg.addressToString, msg.bodyToString)
+			} else {
+        //  Send random value for worker availability
+				val msg = new ZMsg(rand.nextInt(10).toString)
+				msg.wrap(self getBytes)
+				statebe.sendMsg(msg)
+			}
+		}
+	}
+}

--- a/examples/scala/peering2.scala
+++ b/examples/scala/peering2.scala
@@ -1,0 +1,194 @@
+/**
+ *
+ * Broker peering simulation (part 2)
+ * Prototypes the request-reply flow
+ *
+ * While this example runs in a single process, that is just to make
+ * it easier to start and stop the example. Each thread has its own
+ * context and conceptually acts as a separate process.
+ *
+ *
+ * @Author:     Giovanni Ruggiero
+ * @Email:      giovanni.ruggiero@gmail.com
+ */
+
+import org.zeromq.ZMQ
+import ZHelpers._
+import ClusterDns._
+
+object peering2 {
+	val Localfe = "localfe"
+	val Localbe = "localbe"
+	val Cloudfe = "cloudfe"
+	val Cloudbe = "cloudbe"
+
+	implicit val dns = clusterDns
+
+	//  Basic request-reply client using REQ socket
+	//
+	class ClientTask(host: String) extends Runnable {
+		def run() {
+			val ctx = ZMQ.context(1)
+			val client = ctx.socket(ZMQ.REQ)
+			setID(client);
+			client.dnsConnect(host, Localfe)
+
+			//  Send request, get reply
+			client.send("HELLO".getBytes, 0)
+			val reply = client.recv(0)
+			printf("Client: %s\n", new String(reply))
+		}
+	}
+
+	//  Worker using REQ socket to do LRU routing
+	//
+	class WorkerTask(host: String) extends Runnable {
+		def run() {
+			val ctx = ZMQ.context(1)
+			val worker = ctx.socket(ZMQ.REQ)
+			setID(worker);
+			worker.dnsConnect(host, Localbe);
+			//  Tell broker we're ready for work
+			worker.send("READY".getBytes, 0);
+			while (true) {
+				//  Read and save all frames until we get an empty frame
+				//  In this example there is only 1 but it could be more
+				val msg = new ZMsg(worker)
+				printf("Worker: %s\n", msg.bodyToString)
+				msg.stringToBody("OK")
+				msg.send(worker)
+			}
+		}
+	}
+
+  def main(args : Array[String]) {
+		val NOFLAGS = 0
+
+		//  Worker using REQ socket to do LRU routing
+		//
+		val NbrClients = 10;
+		val NbrWorkers = 3;
+
+    //  First argument is this broker's name
+    //  Other arguments are our peers' names
+    //
+    if (args.length < 2) {
+      println ("syntax: peering2 me {you}...")
+      exit()
+    }
+    val self = args(0)
+		implicit val host = self
+    printf ("I: preparing broker at %s...\n", self);
+
+		val rand = new java.util.Random(System.currentTimeMillis)
+		val ctx = ZMQ.context(1)
+    //  Bind cloud frontend to endpoint
+		val cloudfe = ctx.socket(ZMQ.ROUTER)
+		cloudfe.setIdentity(self getBytes)
+		cloudfe.dnsBind(Cloudfe)
+
+		val cloudbe = ctx.socket(ZMQ.ROUTER)
+		cloudbe.setIdentity(self getBytes)
+
+		for (cluster <- (1 until args.length)) {
+			printf ("I: connecting to cloud frontend at '%s'\n", args(cluster))
+			cloudbe.dnsConnect(args(cluster),Cloudbe)
+		}
+    //  Prepare local frontend and backend
+		val localfe = ctx.socket(ZMQ.ROUTER)
+		val localbe = ctx.socket(ZMQ.ROUTER)
+		localfe.dnsBind(Localfe)
+		localbe.dnsBind(Localbe)
+
+    println ("Press Enter when all brokers are started: ");
+		readChar
+
+    //  Start local clients
+		val clients = List.fill(NbrClients)(new Thread(new ClientTask(self)))
+		clients foreach (_.start)
+
+    //  Start local workers
+		val workers = List.fill(NbrWorkers)(new Thread(new WorkerTask(self)))
+		workers foreach (_.start)
+
+    //  Interesting part
+    //  -------------------------------------------------------------
+    //  Request-reply flow
+    //  - Poll backends and process local/cloud replies
+    //  - While worker available, route localfe to local or cloud
+
+    //  Queue of available workers
+
+		val workerQueue = scala.collection.mutable.Queue[Array[Byte]]()
+		val backends = ctx.poller(2)
+
+		backends.register(localbe,ZMQ.Poller.POLLIN)
+		backends.register(cloudbe,ZMQ.Poller.POLLIN)
+
+		var capacity = 0
+		while (true) {
+			//  If we have no workers anyhow, wait indefinitely
+			val timeout = if (capacity > 0) {1000000} else {-1}
+			val ret = backends.poll(timeout)
+			//  Handle reply from local worker
+			var msg = new ZMsg()
+			if (backends.pollin(0)) {
+				msg = new ZMsg(localbe)
+        val workerAddr = msg.unwrap
+				assert(capacity < NbrWorkers)
+				//  Use worker address for LRU routing
+				workerQueue.enqueue(workerAddr)
+				capacity += 1
+				//  Address is READY or else a client reply address
+			} else {
+        //  Or handle reply from peer broker
+				if (backends.pollin(1)) {
+				  msg = new ZMsg(cloudbe)
+				}
+			}
+      //  Route reply to cloud if it's addressed to a broker
+			if (msg != null) {
+				for (cluster <- (1 until args.length)) {
+				  if (new String(msg.address) == cluster) {
+					  cloudfe.sendMsg(msg)
+					}
+				}
+			}
+			//  Route reply to client if we still need to
+			if (msg != null) {
+				localfe.sendMsg(msg)
+			}
+      //  Now route as many clients requests as we can handle
+			while (capacity > 0) {
+				val frontends = ctx.poller(2)
+
+				frontends.register(localfe,ZMQ.Poller.POLLIN)
+				frontends.register(cloudfe,ZMQ.Poller.POLLIN)
+				frontends.poll
+        var reroutable = 0
+        //  We'll do peer brokers first, to prevent starvation
+				if (frontends.pollin(1)) {
+					msg = new ZMsg(cloudfe)
+					reroutable = 0
+				} else if (frontends.pollin(0)) {
+					msg = new ZMsg(localfe)
+					reroutable = 1
+				}
+				//  If reroutable, send to cloud 20% of the time
+        //  Here we'd normally use cloud status information
+				val rand = new java.util.Random
+				if (reroutable > 0 && args.length > 1 && rand.nextInt() % 5 == 0) {
+					//  Route to random broker peer
+					val randomPeer = rand.nextInt(args.length - 1) + 1
+					msg.wrap(args(randomPeer) getBytes)
+					cloudbe.sendMsg(msg)
+				} else {
+					msg.wrap(workerQueue(0))
+					localbe.sendMsg(msg)
+					workerQueue.dequeue
+					capacity -= 1
+				}
+			}
+		}
+	}
+}

--- a/examples/scala/psenvpub.scala
+++ b/examples/scala/psenvpub.scala
@@ -1,0 +1,27 @@
+/*
+ * Pubsub envelope publisher
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+ */
+
+import org.zeromq.ZMQ
+
+object psenvpub {
+  def main(args : Array[String]) {
+
+		// Prepare our context and publisher
+		val context = ZMQ.context(1)
+		val publisher = context.socket(ZMQ.PUB)
+
+		publisher.bind("tcp://*:5563")
+		while (true) {
+			// Write two messages, each with an envelope and content
+			publisher.send("A".getBytes(), ZMQ.SNDMORE)
+			publisher.send("We don't want to see this".getBytes(), 0)
+			publisher.send("B".getBytes(), ZMQ.SNDMORE)
+			publisher.send("We would like to see this".getBytes(), 0)
+			Thread.sleep(1000)
+		}
+	}
+}

--- a/examples/scala/psenvsub.scala
+++ b/examples/scala/psenvsub.scala
@@ -1,0 +1,27 @@
+/*
+ * Pubsub envelope subscriber
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+ */
+
+import org.zeromq.ZMQ
+
+object psenvsub {
+  def main(args : Array[String]) {
+
+		// Prepare our context and subscriber
+		val context = ZMQ.context(1)
+		val subscriber = context.socket(ZMQ.SUB)
+
+		subscriber.connect("tcp://localhost:5563")
+		subscriber.subscribe("B".getBytes())
+		while (true) {
+			// Read envelope with address
+			val address = new String(subscriber.recv(0))
+			// Read message contents
+			val contents = new String(subscriber.recv(0))
+			println(address + " : " + contents)
+		}
+	}
+}

--- a/examples/scala/rrbroker.scala
+++ b/examples/scala/rrbroker.scala
@@ -1,0 +1,66 @@
+/*
+ * Simple request-reply broker
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+ *
+ */
+
+import org.zeromq.ZMQ
+
+object rrbroker  {
+  def main(args : Array[String]) {
+		//  Prepare our context and sockets
+		val context = ZMQ.context(1)
+
+		val frontend = context.socket(ZMQ.ROUTER)
+		val backend  = context.socket(ZMQ.DEALER)
+		frontend.bind("tcp://*:5559")
+		backend.bind("tcp://*:5560")
+
+		System.out.println("launch and connect broker.")
+
+		//  Initialize poll set
+		val items = context.poller(2)
+		items.register(frontend, 1)
+		items.register(backend, 1)
+
+		var more = false
+
+		//  Switch messages between sockets
+		while (!Thread.currentThread().isInterrupted()) {
+			//  poll and memorize multipart detection
+			items.poll()
+
+			if (items.pollin(0)) {
+			do {
+				// receive message
+				val message = frontend.recv(0)
+				more = frontend.hasReceiveMore
+
+				// Broker it
+				if (more)
+					backend.send(message, ZMQ.SNDMORE)
+				else
+					backend.send(message, 0)
+			} while (more)
+			}
+			if (items.pollin(1)) {
+			do {
+				// receive message
+				val message = backend.recv(0)
+				more = backend.hasReceiveMore()
+				// Broker it
+				if (more)
+					frontend.send(message, ZMQ.SNDMORE)
+				else
+					frontend.send(message, 0)
+			} while (more)
+			}
+		}
+		//  We never get here but clean up anyhow
+		frontend.close()
+		backend.close()
+		context.term()
+	}
+}

--- a/examples/scala/rrclient.scala
+++ b/examples/scala/rrclient.scala
@@ -1,0 +1,35 @@
+/*
+ *  Hello World client in Scala
+ *  Connects REQ socket to tcp://localhost:5555
+ *  Sends "Hello" to server, expects "World" back
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+*/
+
+import org.zeromq.ZMQ
+import org.zeromq.ZMQ.{Context,Socket}
+
+object rrclient{
+  def main(args : Array[String]) {
+    //  Prepare our context and socket
+    val context = ZMQ.context(1)
+    val requester = context.socket(ZMQ.REQ)
+
+    requester.connect ("tcp://localhost:5559")
+
+		for (request_nbr <- 1 to 10)  {
+			val request = "Hello ".getBytes()
+      request(request.length-1)=0 //Sets the last byte to 0
+      // Send the message
+      println("Sending request " + request_nbr + "...") + request.toString
+      requester.send(request, 0)
+
+      //  Get the reply.
+      val reply = requester.recv(0)
+      //  When displaying reply as a String, omit the last byte because
+      //  our "Hello World" server has sent us a 0-terminated string:
+      println("Received reply " + request_nbr + ": [" + new String(reply,0,reply.length-1) + "]")
+    }
+  }
+}

--- a/examples/scala/rrserver.scala
+++ b/examples/scala/rrserver.scala
@@ -1,0 +1,46 @@
+/*
+ *  Hello World server in Scala
+ *  Binds REP socket to tcp://localhost:5560
+ *  Expects "Hello" from client, replies with "World"
+ *
+ *  @author Giovanni Ruggiero
+ *  @email giovanni.ruggiero@gmail.com
+ *
+*/
+
+import org.zeromq.ZMQ
+import org.zeromq.ZMQ.{Context,Socket}
+
+object rrserver {
+  def main(args : Array[String]) {
+    //  Prepare our context and socket
+    val context = ZMQ.context(1)
+    val receiver = context.socket(ZMQ.REP)
+		receiver.connect("tcp://localhost:5560")
+
+    while (true) {
+      //  Wait for next request from client
+      //  We will wait for a 0-terminated string (C string) from the client,
+      //  so that this server also works with The Guide's C and C++ "Hello World" clients
+      val request = receiver.recv (0)
+      //  In order to display the 0-terminated string as a String,
+      //  we omit the last byte from request
+      println ("Received request: [" + new String(request,0,request.length-1)  //  Creates a String from request, minus the last byte
+							 + "]")
+
+      //  Do some 'work'
+      try {
+        Thread.sleep (1000)
+      } catch  {
+        case e: InterruptedException => e.printStackTrace()
+      }
+
+      //  Send reply back to client
+      //  We will send a 0-terminated string (C string) back to the client,
+      //  so that this server also works with The Guide's C and C++ "Hello World" clients
+      val reply = "World ".getBytes
+      reply(reply.length-1)=0 //Sets the last byte of the reply to 0
+      receiver.send(reply, 0)
+    }
+  }
+}

--- a/examples/scala/rtdealer.scala
+++ b/examples/scala/rtdealer.scala
@@ -1,0 +1,87 @@
+/**
+ * Custom routing Router to Dealer. (ROUTER to DEALER)
+ * Scala version, based on the C version from
+ * http://zguide.zeromq.org/chapter:all#toc45
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+ */
+
+import org.zeromq.ZMQ
+
+import java.util.Arrays
+import java.util.Random
+
+
+/**
+ * Router-to-dealer custom routing demo.
+ *
+ * The router, in this case the main function, uses ROUTER.  The
+ * dealers, in this case the two worker threads, use DEALER.
+ */
+object rtdealer  {
+  val NOFLAGS = 0
+
+  /**
+   * Worker runnable consumes messages until it receives an END
+   * message.
+   */
+  class Worker(name: String) extends Runnable {
+
+    def run() {
+      val context = ZMQ.context(1)
+      val socket = context.socket(ZMQ.DEALER)
+      socket.setIdentity(name.getBytes())
+      socket.connect("tcp://localhost:5555")
+
+      var total = 0
+			var workload = ""
+			do {
+				 workload = new String(socket.recv(NOFLAGS))
+				total += 1
+			} while (!workload.equalsIgnoreCase("END"))
+			printf( "Worker %s received %d messages.\n", name, total )
+      socket.close
+      context.term
+    }
+  }
+
+  /* Random number generator to determine message distribution. */
+  val rand = new Random
+
+  def main(args : Array[String])  {
+    val context = ZMQ.context(1)
+    val socket = context.socket(ZMQ.ROUTER)
+    socket.bind("tcp://*:5555")
+
+    val workerA = new Thread(new Worker("A"))
+    val workerB = new Thread(new Worker("B"))
+    workerA.start()
+    workerB.start()
+
+    // Wait a second for the workers to connect their sockets.
+    println("Workers started, sleeping 1 second for warmup.")
+    Thread.sleep(1000)
+
+    // Send 10 tasks, scattered to A twice as often as B.
+		var address = Array[Byte]()
+    for (i <- 1 to 10) {
+      if (rand.nextInt() % 3 == 0) { // 1/3 to B.
+        address = "B".getBytes()
+      } else { // 2/3 to A.
+        address = "A".getBytes()
+			}
+      socket.send(address, ZMQ.SNDMORE)
+      socket.send("This is the workload.".getBytes, NOFLAGS)
+    }
+    socket.send("A".getBytes, ZMQ.SNDMORE)
+    socket.send("END".getBytes, NOFLAGS)
+
+    socket.send("B".getBytes, ZMQ.SNDMORE)
+    socket.send("END".getBytes, NOFLAGS)
+
+    socket.close
+    context.term
+  }
+
+}

--- a/examples/scala/rtmama.scala
+++ b/examples/scala/rtmama.scala
@@ -1,0 +1,74 @@
+/*
+ *  Custom routing Router to Mama (ROUTER to REQ)
+ *
+ *  While this example runs in a single process, that is just to make
+ *  it easier to start and stop the example. Each thread has its own
+ *  context and conceptually acts as a separate process.
+ *
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+ */
+
+import org.zeromq.ZMQ
+import ZHelpers._
+
+object rtmama {
+
+  class WorkerTask() extends Runnable {
+    def run() {
+			val rand = new java.util.Random(System.currentTimeMillis)
+			val ctx = ZMQ.context(1)
+			val worker = ctx.socket(ZMQ.REQ)
+			//  We use a string identity for ease here
+			setID(worker)
+			// println(new String(worker.getIdentity))
+			worker.connect("tcp://localhost:5555")
+			var total = 0
+			var workload = ""
+      do {
+				//  Tell the router we're ready for work
+				worker.send("Ready".getBytes,0)
+				workload = new String(worker.recv(0))
+				Thread.sleep (rand.nextInt(1) * 1000)
+				total += 1
+				//  Get workload from router, until finished
+			} while (!workload.equalsIgnoreCase("END"))
+			printf("Processed: %d tasks\n", total)
+		}
+	}
+
+  def main(args : Array[String]) {
+		val NBR_WORKERS = 10
+		val ctx = ZMQ.context(1)
+		val client = ctx.socket(ZMQ.ROUTER)
+
+		// Workaround to ckeck version >= 2.1
+		assert(client.getType > -1)
+		client.bind("tcp://*:5555")
+		val workers = List.fill(NBR_WORKERS)(new Thread(new WorkerTask))
+		workers foreach (_.start)
+
+		for (i <- 1 to NBR_WORKERS * 10) {
+			//  LRU worker is next waiting in queue
+			val address = client.recv(0)
+			val empty = client.recv(0)
+			val ready = client.recv(0)
+
+			client.send(address, ZMQ.SNDMORE)
+			client.send("".getBytes, ZMQ.SNDMORE)
+			client.send("This is the workload".getBytes,0)
+		}
+
+		//  Now ask mamas to shut down and report their results
+		for (i <- 1 to NBR_WORKERS) {
+			val address = client.recv(0)
+			val empty = client.recv(0)
+			val ready = client.recv(0)
+
+			client.send(address, ZMQ.SNDMORE)
+			client.send("".getBytes, ZMQ.SNDMORE)
+			client.send("END".getBytes,0)
+		}
+	}
+}

--- a/examples/scala/rtpapa.scala
+++ b/examples/scala/rtpapa.scala
@@ -1,0 +1,46 @@
+/*
+ *  Custom routing Router to Papa (ROUTER to REP)
+ *
+ *
+ *  @Author:     Giovanni Ruggiero
+ *  @Email:      giovanni.ruggiero@gmail.com
+ */
+
+import org.zeromq.ZMQ
+import ZHelpers._
+
+object rtpapa  {
+  def main(args : Array[String]) {
+		val NOFLAGS = 0
+		//  We will do this all in one thread to emphasize the sequence
+		//  of events...
+		val ctx = ZMQ.context(1)
+		val client = ctx.socket(ZMQ.ROUTER)
+		val worker = ctx.socket(ZMQ.REP)
+
+		client.bind("inproc://routing")
+		worker.setIdentity("A".getBytes)
+		worker.connect("inproc://routing")
+
+		//  Wait for the worker to connect so that when we send a message
+		//  with routing envelope, it will actually match the worker...
+		Thread.sleep(1000)
+
+		//  Send papa address, address stack, empty part, and request
+		client.send("A".getBytes, ZMQ.SNDMORE)
+		client.send("address 3".getBytes, ZMQ.SNDMORE)
+		client.send("address 2".getBytes, ZMQ.SNDMORE)
+		client.send("address 1".getBytes, ZMQ.SNDMORE)
+		client.send("".getBytes, ZMQ.SNDMORE)
+		client.send("This is the workload".getBytes, NOFLAGS)
+
+		//  Worker should get just the workload
+		dump(worker)
+
+		//  We don't play with envelopes in the worker
+		worker.send("This is the reply".getBytes, NOFLAGS)
+
+		//  Now dump what we got off the ROUTER socket...
+		dump(client)
+	}
+}

--- a/examples/scala/rtrouter.scala
+++ b/examples/scala/rtrouter.scala
@@ -1,0 +1,38 @@
+/*
+ *  Cross-connected ROUTER sockets addressing each other
+ *
+ *
+ *  @Author:     Giovanni Ruggiero
+ *  @Email:      giovanni.ruggiero@gmail.com
+*/
+
+import org.zeromq.ZMQ
+import ZHelpers._
+
+object rtrouter  {
+  def main(args : Array[String]) {
+		val ctx = ZMQ.context(1)
+		val worker = ctx.socket(ZMQ.ROUTER)
+    worker.setIdentity("WORKER" getBytes)
+		worker.bind("tcp://*:5555")
+
+		val server = ctx.socket(ZMQ.ROUTER)
+    server.setIdentity("SERVER" getBytes)
+		server.connect("tcp://localhost:5555")
+
+    //  Wait for the worker to connect so that when we send a message
+    //  with routing envelope, it will actually match the worker...
+		Thread.sleep(1000)
+
+		server.send("WORKER" getBytes, ZMQ.SNDMORE)
+		server.send("" getBytes, ZMQ.SNDMORE)
+		server.send("send to worker" getBytes,0)
+		dump(worker)
+
+		worker.send("SERVER" getBytes, ZMQ.SNDMORE)
+		worker.send("" getBytes, ZMQ.SNDMORE)
+		worker.send("send to server" getBytes,0)
+		dump(server)
+
+	}
+}

--- a/examples/scala/tasksink.scala
+++ b/examples/scala/tasksink.scala
@@ -1,0 +1,42 @@
+/*
+ *
+ *  Task sink in Scala
+ *  Binds PULL socket to tcp://localhost:5558
+ *  Collects results from workers via that socket
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+*/
+
+import org.zeromq.ZMQ
+object tasksink {
+  def main(args : Array[String]) {
+
+		//  Prepare our context and socket
+		val context = ZMQ.context(1)
+		val receiver = context.socket(ZMQ.PULL)
+		receiver.bind("tcp://*:5558")
+
+		//  Wait for start of batch
+		val string = new String(receiver.recv(0))
+
+		//  Start our clock now
+		val tstart = System.currentTimeMillis()
+
+		//  Process 100 confirmations
+		val total_msec = 0     //  Total calculated cost in msecs
+		for (task_nbr <- 1 to 100 ) {
+			val string = new String(receiver.recv(0)).trim()
+			if ((task_nbr / 10) * 10 == task_nbr) {
+				System.out.print(":")
+			} else {
+				System.out.print(".")
+			}
+			System.out.flush()
+		}
+		//  Calculate and report duration of batch
+		val tend = System.currentTimeMillis()
+
+		println("Total elapsed time: " + (tend - tstart) + " msec")
+	}
+}

--- a/examples/scala/taskvent.scala
+++ b/examples/scala/taskvent.scala
@@ -1,0 +1,47 @@
+/*
+ *
+ *  Task ventilator in Scala
+ *  Binds PUSH socket to tcp://localhost:5557
+ *  Sends batch of tasks to workers via that socket
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+*/
+
+import java.util.Random
+import org.zeromq.ZMQ
+
+object taskvent {
+  def main(args : Array[String]) {
+
+		val context = ZMQ.context(1)
+
+		//  Socket to send messages on
+		val sender = context.socket(ZMQ.PUSH)
+		sender.bind("tcp://*:5557")
+
+		println("Press Enter when the workers are ready: ")
+		System.in.read()
+		println("Sending tasks to workers...\n")
+
+		//  The first message is "0" and signals start of batch
+		sender.send("0\u0000".getBytes(), 0)
+
+		//  Initialize random number generator
+		val srandom = new Random(System.currentTimeMillis())
+
+		//  Send 100 tasks
+		var total_msec = 0     //  Total expected cost in msecs
+		for (i <- 1 to 100 ) {
+			//  Random workload from 1 to 100msecs
+			val workload = srandom.nextInt(100) + 1
+			total_msec += workload
+			print(workload + ".")
+			val string = String.format("%d\u0000", workload.asInstanceOf[Integer] )
+			sender.send(string.getBytes(), 0)
+		}
+		println("Total expected cost: " + total_msec + " msec")
+
+		Thread.sleep(1000)              //  Give 0MQ time to deliver
+	}
+}

--- a/examples/scala/taskwork.scala
+++ b/examples/scala/taskwork.scala
@@ -1,0 +1,41 @@
+/*
+ *  Task worker in Scala
+ *  Connects PULL socket to tcp://localhost:5557
+ *  Collects workloads from ventilator via that socket
+ *  Connects PUSH socket to tcp://localhost:5558
+ *  Sends results to sink via that socket
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+*/
+
+import org.zeromq.ZMQ
+
+object taskwork {
+  def main(args : Array[String]) {
+		val context = ZMQ.context(1)
+
+		//  Socket to receive messages on
+		val receiver = context.socket(ZMQ.PULL)
+		receiver.connect("tcp://localhost:5557")
+
+		//  Socket to send messages to
+		val sender = context.socket(ZMQ.PUSH)
+		sender.connect("tcp://localhost:5558")
+
+		//  Process tasks forever
+		while (true) {
+			val string = new String(receiver.recv(0)).trim()
+			val nsec = string.toLong * 1000
+			//  Simple progress indicator for the viewer
+			System.out.flush()
+			print(string + '.')
+
+			//  Do the work
+			Thread.sleep(nsec)
+
+			//  Send results to sink
+			sender.send("".getBytes(), 0)
+		}
+	}
+}

--- a/examples/scala/utils.scala
+++ b/examples/scala/utils.scala
@@ -1,0 +1,74 @@
+/*
+ * Utility methods
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+*/
+
+import org.zeromq.ZMQ.Socket
+import org.zeromq.ZMQ
+import java.util.Random
+
+object ZHelpers {
+
+  private var rand: Random = null
+
+  private def GetRandomGen() = {
+    if (rand == null)
+      rand = new Random(System.currentTimeMillis)
+    rand
+  }
+
+  private def decodeUUID(data: Array[Byte]) = {
+		println(new String(data))
+		val hex = "0123456789ABCDEF"
+		val uuid = new Array[Char](33)
+    uuid(0) = '@'
+		for (byteNbr <- 0 until 16)  {
+			println(byteNbr)
+			println(data(byteNbr + 1))
+			println(data(byteNbr + 1) >> 4)
+			uuid(byteNbr * 2 + 1) = hex(data(byteNbr + 1) >> 4)
+			uuid(byteNbr * 2 + 2) = hex(data(byteNbr + 1) & 15)
+    }
+    new String(uuid)
+  }
+
+	implicit def jSocket2cSocket(socket: Socket) = new pmpdSocket(socket)
+
+  def setID(socket: Socket) {
+		val rand = GetRandomGen
+		socket.setIdentity((rand.nextLong.toString + "-" + rand.nextLong.toString).getBytes)
+  }
+
+  def dump(socket: Socket) = {
+    println(new String("-") * 38)
+		for (msg <- socket.recvAll(0)) {
+			printf("[%d] ",msg.length)
+ 			if (msg.length == 17 && msg(0) == 0)  {
+        // println(decodeUUID(msg).substring(1))
+        println( "UUID " + new String(msg))
+      } else {
+        println(new String(msg))
+      }
+		}
+  }
+
+	class pmpdSocket(socket: Socket) {
+		def recvAll(flags: Int) = {
+			val messages = scala.collection.mutable.Queue[Array[Byte]]()
+			messages.enqueue(socket.recv(flags))
+			while (socket.hasReceiveMore) {
+				messages.enqueue(socket.recv(flags))
+			}
+			messages
+		}
+
+		def sendMsg(msg: ZMsg) =  msg send socket
+
+		def recvMsg() = new ZMsg(socket)
+
+		def dnsBind(port: String)(implicit host: String, dns: Dns) = socket.bind(dns.bind(host, port))
+		def dnsConnect(host: String, port: String)(implicit dns: Dns) = socket.connect(dns.endPoint(host, port))
+	}
+}

--- a/examples/scala/wuclient.scala
+++ b/examples/scala/wuclient.scala
@@ -1,0 +1,40 @@
+/*
+ *  Weather update client in Scala
+ *  Connects SUB socket to tcp://localhost:5556
+ *  Collects weather updates and finds avg temp in zipcode
+ *
+ * @author Giovanni Ruggiero
+ * @email giovanni.ruggiero@gmail.com
+*/
+
+import java.util.StringTokenizer
+import org.zeromq.ZMQ
+
+object wuclient {
+
+  def main(args : Array[String]) {
+		val context = ZMQ.context(1)
+
+		//  Socket to talk to server
+		println("Collecting updates from weather server...")
+		val subscriber = context.socket(ZMQ.SUB)
+		subscriber.connect("tcp://localhost:5556")
+
+		//  Subscribe to zipcode, default is NYC, 10001
+		val filter = {if (args.length > 0)  args(0) else "10001 "}
+		subscriber.subscribe(filter.getBytes())
+
+		//  Process 100 updates
+		val update_nbr = 100
+		var total_temp = 0
+		for (i <- 1 to update_nbr ) {
+			//  Use trim to remove the tailing '0' character
+			val sscanf = new String(subscriber.recv(0)).trim.split(' ').map(_.toInt)
+			val zipcode = sscanf(0)
+			val temperature = sscanf(1)
+			val relhumidity = sscanf(2)
+			total_temp += temperature
+		}
+		println("Average temperature for zipcode '" + filter + "' was " +  (total_temp / update_nbr))
+	}
+}

--- a/examples/scala/wuserver.scala
+++ b/examples/scala/wuserver.scala
@@ -1,0 +1,34 @@
+//
+//  Weather update server in Scala
+//  Binds PUB socket to tcp://*:5556
+//  Publishes random weather updates
+//
+//  author Giovanni Ruggiero
+//  email giovanni.ruggiero@gmail.com
+
+import java.util.Random
+import org.zeromq.ZMQ
+
+object wuserver {
+  def main(args : Array[String]) {
+
+		//  Prepare our context and publisher
+		val context = ZMQ.context(1)
+		val publisher = context.socket(ZMQ.PUB)
+
+		publisher.bind("tcp://*:5556")
+
+		//  Initialize random number generator
+		val srandom = new Random(System.currentTimeMillis())
+		while (true) {
+			//  Get values that will fool the boss
+			val zipcode: Integer = srandom.nextInt(100000) + 1
+			val temperature: Integer = srandom.nextInt(215) - 80 + 1
+			val relhumidity: Integer = srandom.nextInt(50) + 10 + 1
+
+			//  Send message to all subscribers
+			val update = String.format("%05d %d %d\u0000", zipcode, temperature, relhumidity);
+			publisher.send(update.getBytes(), 0)
+		}
+	}
+}


### PR DESCRIPTION
Hi,

I've looked at 0MQ in the past weeks and I've found it really interesting.
In studying the guide I've translated some of the samples in Scala, the language I'm using.
At the moment I've implemented (almost) all the samples up to the chapter 3, but I'm committed to complete the guide.
The samples heve been tested versus 0MQ 2.1.6, in the next days I'll test them against 2.1.7.
I've used the existing JNI binding, modified with two more flags for ZMQ.ROUTER and ZMQ.DEALER.
Two utility classes have been added to supply the ZHelpers functions and zmsg abstractions.

I'm on Windows, so all the samples using IPC have been adapted.
In specific, for the peering sample, a micro DNS has been created to route the messages.

I've tried to find a good mix between the readability of the samples (the firsts are almost a verbatim copy of the Java ones) and the idiomatic use of the Scala language.
Of course all constructive critics are welcome.

Keep up this awesome library.

Best regards
Giovanni Ruggiero
