### PR TITLE
Haxe language bindings for chapter one and two

### DIFF
--- a/examples/Haxe/DuraPub.hx
+++ b/examples/Haxe/DuraPub.hx
@@ -1,0 +1,51 @@
+package ;
+import neko.Lib;
+import haxe.io.Bytes;
+import neko.Sys;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Publisher for durable subscriber
+ * 
+ * See: http://zguide.zeromq.org/page:all#-Semi-Durable-Subscribers-and-High-Water-Marks
+ * 
+ * Use with DuraSub.hx
+ */
+class DuraPub 
+{
+
+    public static function main() {
+        var context:ZMQContext = ZMQContext.instance();
+        
+        Lib.println("** DuraPub (see: http://zguide.zeromq.org/page:all#-Semi-Durable-Subscribers-and-High-Water-Marks)");
+        
+        // Subscriber tells us when it is ready here
+        var sync:ZMQSocket = context.socket(ZMQ_PULL);
+        sync.bind("tcp://*:5564");
+        
+        // We send updates via this socket
+        var publisher:ZMQSocket = context.socket(ZMQ_PUB);
+        
+        // Uncomment next line to see effect of adding a high water mark to the publisher
+        // publisher.setsockopt(ZMQ_HWM, { hi:0, lo: 2 } );   // Set HWM to 2
+        
+        publisher.bind("tcp://*:5565");
+        
+        // Wait for synchronisation request
+        sync.recvMsg();
+        
+        for (update_nbr in 0 ... 10) {
+            var str = "Update " + update_nbr;
+            Lib.println(str);
+            publisher.sendMsg(Bytes.ofString(str));
+            Sys.sleep(1.0);
+        }
+        publisher.sendMsg(Bytes.ofString("END"));
+        
+        sync.close();
+        publisher.close();
+        context.term();
+    }
+}

--- a/examples/Haxe/DuraPub2.hx
+++ b/examples/Haxe/DuraPub2.hx
@@ -1,0 +1,53 @@
+package ;
+import neko.Lib;
+import haxe.io.Bytes;
+import neko.Sys;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Publisher for durable but cynical subscriber
+ * 
+ * See: http://zguide.zeromq.org/page:all#-Semi-Durable-Subscribers-and-High-Water-Marks
+ * 
+ * Use with DuraSub.hx
+ */
+class DuraPub2 
+{
+
+    public static function main() {
+        var context:ZMQContext = ZMQContext.instance();
+        
+        Lib.println("** DuraPub2 (see: http://zguide.zeromq.org/page:all#-Semi-Durable-Subscribers-and-High-Water-Marks)");
+        
+        // Subscriber tells us when it is ready here
+        var sync:ZMQSocket = context.socket(ZMQ_PULL);
+        sync.bind("tcp://*:5564");
+        
+        // We send updates via this socket
+        var publisher:ZMQSocket = context.socket(ZMQ_PUB);
+        publisher.bind("tcp://*:5565");
+        
+        // Prevent publisher overflowing because of slow subscribers
+        publisher.setsockopt(ZMQ_HWM, { hi:0, lo: 1 } );   // Set HWM to 1
+        
+        // Specify swap space in bytes, this covers all subscribers
+        publisher.setsockopt(ZMQ_SWAP, { hi:0, lo: 25000000 } );
+        
+        // Wait for synchronisation request
+        sync.recvMsg();
+        
+        for (update_nbr in 0 ... 10) {
+            var str = "Update " + update_nbr;
+            Lib.println(str);
+            publisher.sendMsg(Bytes.ofString(str));
+            Sys.sleep(1.0);
+        }
+        publisher.sendMsg(Bytes.ofString("END"));
+        
+        sync.close();
+        publisher.close();
+        context.term();
+    }
+}

--- a/examples/Haxe/DuraSub.hx
+++ b/examples/Haxe/DuraSub.hx
@@ -1,0 +1,45 @@
+package ;
+import haxe.io.Bytes;
+import neko.Lib;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Durable subscriber
+ * 
+ * See: http://zguide.zeromq.org/page:all#-Semi-Durable-Subscribers-and-High-Water-Marks
+ * 
+ * Use with DuraPub.hx and DuraPub2.hx
+ */
+class DuraSub 
+{
+
+    public static function main() {
+        var context:ZMQContext = ZMQContext.instance();
+        
+        Lib.println("** DuraSub (see: http://zguide.zeromq.org/page:all#-Semi-Durable-Subscribers-and-High-Water-Marks)");
+        
+        var subscriber:ZMQSocket = context.socket(ZMQ_SUB);
+        subscriber.setsockopt(ZMQ_IDENTITY, Bytes.ofString("Hello"));
+        subscriber.setsockopt(ZMQ_SUBSCRIBE, Bytes.ofString(""));
+        subscriber.connect("tcp://127.0.0.1:5565");
+        
+        // Synschronise with publisher
+        var sync:ZMQSocket = context.socket(ZMQ_PUSH);
+        sync.connect("tcp://127.0.0.1:5564");
+        sync.sendMsg(Bytes.ofString(""));
+        
+        // Get updates, exit when told to do so
+        while (true) {
+            var msgString:String = subscriber.recvMsg().toString();
+            Lib.println(msgString + "\n");
+            if (msgString == "END") {
+                break;
+            }
+        }
+        sync.close();
+        subscriber.close();
+        context.term();
+    }
+}

--- a/examples/Haxe/HelloWorldClient.hx
+++ b/examples/Haxe/HelloWorldClient.hx
@@ -1,0 +1,45 @@
+package ;
+import haxe.io.Bytes;
+import neko.Lib;
+import neko.Sys;
+
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Hello World client in Haxe.
+ * Use with HelloWorldServer.hx and MTServer.hx
+ */
+class HelloWorldClient 
+{
+	
+	public static function main() {
+		var context:ZMQContext = ZMQContext.instance();
+		var socket:ZMQSocket = context.socket(ZMQ_REQ);
+		
+		Lib.println("** HelloWorldClient (see: http://zguide.zeromq.org/page:all#Ask-and-Ye-Shall-Receive)");
+		
+		trace ("Connecting to hello world server...");
+		socket.connect ("tcp://localhost:5556");
+		
+		// Do 10 requests, waiting each time for a response
+		for (i in 0...10) {
+			var requestString = "Hello ";
+			
+			// Send the message
+			trace ("Sending request " + i + " ...");
+			socket.sendMsg(Bytes.ofString(requestString));
+			
+			// Wait for the reply
+			var msg:Bytes = socket.recvMsg();
+			
+			trace ("Received reply " + i + ": [" + msg.toString() + "]");
+			
+		}
+		
+		// Shut down socket and context
+		socket.close();
+		context.term();
+	}
+}

--- a/examples/Haxe/HelloWorldServer.hx
+++ b/examples/Haxe/HelloWorldServer.hx
@@ -1,0 +1,51 @@
+package ;
+import haxe.io.Bytes;
+import neko.Lib;
+import neko.Sys;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQException;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Hello World server in Haxe
+ * Binds REP to tcp://*:5556
+ * Expects "Hello" from client, replies with "World"
+ * Use with HelloWorldClient.hx
+ * 
+ */
+class HelloWorldServer 
+{
+
+	public static function main() {
+		
+		var context:ZMQContext = ZMQContext.instance();
+		var responder:ZMQSocket = context.socket(ZMQ_REP);
+
+		Lib.println("** HelloWorldServer (see: http://zguide.zeromq.org/page:all#Ask-and-Ye-Shall-Receive)");
+
+		responder.setsockopt(ZMQ_LINGER, 0);
+		responder.bind("tcp://*:5556");
+		
+		try {
+			while (true) {
+				// Wait for next request from client
+				var request:Bytes = responder.recvMsg();
+				
+				trace ("Received request:" + request.toString());
+				
+				// Do some work
+				Sys.sleep(1);
+				
+				// Send reply back to client
+				responder.sendMsg(Bytes.ofString("World"));
+			}
+		} catch (e:ZMQException) {
+			trace (e.toString());
+		}
+		responder.close();
+		context.term();
+		
+	}
+	
+}

--- a/examples/Haxe/Interrupt.hx
+++ b/examples/Haxe/Interrupt.hx
@@ -1,0 +1,51 @@
+package ;
+
+import haxe.io.Bytes;
+import haxe.Stack;
+import neko.Lib;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Signal Handling
+ * 
+ * Call 
+ */
+class Interrupt 
+{
+
+	public static function main() {
+		var context:ZMQContext = ZMQContext.instance();
+		var receiver:ZMQSocket = context.socket(ZMQ_REP);
+		receiver.bind("tcp://127.0.0.1:5559");
+		
+		Lib.println("** Interrupt (see: http://zguide.zeromq.org/page:all#Handling-Interrupt-Signals)");
+		
+		ZMQ.catchSignals();
+		
+		Lib.println ("\nPress Ctrl+C");
+
+		while (true) {
+			// Blocking read, will exit only on an interrupt (Ctrl+C)
+			
+			try {
+			   var msg:Bytes = receiver.recvMsg();
+			} catch (e:ZMQException) {
+				if (ZMQ.isInterrupted()) {
+					trace ("W: interrupt received, killing server ...\n");
+					break;
+				}
+				
+				// Handle other errors
+				trace("ZMQException #:" + e.errNo + ", str:" + e.str());
+				trace (Stack.toString(Stack.exceptionStack()));
+			}
+		}
+		// Close up gracefully
+		receiver.close();
+		context.term();
+		
+		
+	}
+}

--- a/examples/Haxe/MTRelay.hx
+++ b/examples/Haxe/MTRelay.hx
@@ -1,0 +1,99 @@
+package ;
+
+import haxe.io.Bytes;
+#if !php
+import neko.vm.Thread;
+#end
+import neko.Lib;
+
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Multi-threaded relay in haXe
+ * 
+ */
+class MTRelay 
+{
+    
+    static function step1() {
+        var context:ZMQContext = ZMQContext.instance();
+        
+        // Connect to step2 and tell it we are ready
+        var xmitter:ZMQSocket = context.socket(ZMQ_PAIR);
+#if (neko || cpp)        
+        xmitter.connect("inproc://step2");
+#elseif php
+        xmitter.connect("ipc://step2.ipc");
+#end        
+        xmitter.sendMsg(Bytes.ofString("READY"));
+        xmitter.close();
+    }
+    
+    static function step2() {
+        var context:ZMQContext = ZMQContext.instance();
+        
+        // Bind inproc socket before starting step 1
+        var receiver:ZMQSocket = context.socket(ZMQ_PAIR);
+#if (neko || cpp)        
+        receiver.bind("inproc://step2");
+        Thread.create(step1);
+#elseif php
+        receiver.bind("ipc://step2.ipc");
+        untyped __php__('
+            $pid = pcntl_fork();
+            if($pid == 0) {
+                step1();
+                exit();
+            }');
+#end            
+        // Wait for signal and pass it on
+        var msgBytes = receiver.recvMsg();
+        receiver.close();
+        
+        // Connect to step3 and tell it we are ready
+        var xmitter:ZMQSocket = context.socket(ZMQ_PAIR);
+#if (neko || cpp)        
+        xmitter.connect("inproc://step3");
+#elseif php
+        xmitter.connect("ipc://step3.ipc");
+#end        
+        xmitter.sendMsg(Bytes.ofString("READY"));
+        xmitter.close();
+    }
+    
+    public static function main() {
+        var context:ZMQContext = ZMQContext.instance();
+        
+		Lib.println ("** MTRelay (see: http://zguide.zeromq.org/page:all#Signaling-between-Threads)");
+
+        // This main thread represents Step 3
+        
+        // Bind to inproc: endpoint then start upstream thread
+        var receiver:ZMQSocket = context.socket(ZMQ_PAIR);
+#if (neko || cpp)        
+        receiver.bind("inproc://step3");
+ 
+        // Step2 relays the signal to step 3
+        Thread.create(step2);
+#elseif php
+        // Use child processes instead of Threads
+        receiver.bind("ipc://step3.ipc");
+        // Step2 relays the signal to step 3
+        untyped __php__('
+            $pid = pcntl_fork();
+            if ($pid == 0) {
+                step2();
+                exit();
+            }');
+        
+#end        
+        // Wait for signal
+        var msgBytes = receiver.recvMsg();
+        receiver.close();
+        
+        trace ("Test successful!");
+        context.term();
+    }
+}

--- a/examples/Haxe/MTServer.hx
+++ b/examples/Haxe/MTServer.hx
@@ -1,0 +1,159 @@
+package ;
+
+import haxe.io.Bytes;
+import haxe.Stack;
+import neko.Lib;
+import neko.Sys;
+#if !php
+import neko.vm.Thread;
+#end
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQPoller;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Multithreaded Hello World Server
+ * 
+ * See: http://zguide.zeromq.org/page:all#Multithreading-with-MQ
+ * Use with HelloWorldClient.hx
+ * 
+ */
+class MTServer 
+{
+
+	static function worker() {
+		var context:ZMQContext = ZMQContext.instance();
+		
+		// Socket to talk to dispatcher
+		var responder:ZMQSocket = context.socket(ZMQ_REP);
+#if (neko || cpp)        
+		responder.connect("inproc://workers");
+#elseif php
+        responder.connect("ipc://workers.ipc");
+#end        
+		ZMQ.catchSignals();
+		
+		while (true) {
+			
+			try {
+				// Wait for next request from client
+				var request:Bytes = responder.recvMsg();
+				
+				trace ("Received request:" + request.toString());
+				
+				// Do some work
+				Sys.sleep(1);
+				
+				// Send reply back to client
+				responder.sendMsg(Bytes.ofString("World"));
+			} catch (e:ZMQException) {
+				if (ZMQ.isInterrupted()) {
+					break;
+				}
+				trace (e.toString());
+			}
+		} 
+		responder.close();
+		return null;
+	}
+	
+	/**
+	 * Implements a reqeust/reply QUEUE broker device
+	 * Returns if poll is interrupted
+	 * @param	ctx
+	 * @param	frontend
+	 * @param	backend
+	 */
+	static function queueDevice(ctx:ZMQContext, frontend:ZMQSocket, backend:ZMQSocket) {
+		
+		// Initialise pollset
+		var poller:ZMQPoller = ctx.poller();
+		poller.registerSocket(frontend, ZMQ.ZMQ_POLLIN());
+		poller.registerSocket(backend, ZMQ.ZMQ_POLLIN());
+		
+		ZMQ.catchSignals();
+		
+		while (true) {
+			try {
+				poller.poll();
+				if (poller.pollin(1)) {
+					var more:Bool = true;
+					while (more) {
+						// Receive message
+						var msg = frontend.recvMsg();
+						more = frontend.hasReceiveMore();
+						
+						// Broker it
+						backend.sendMsg(msg, { if (more) SNDMORE else null; } );
+					}
+				}
+				
+				if (poller.pollin(2)) {
+					var more:Bool = true;
+					while (more) {
+						// Receive message
+						var msg = backend.recvMsg();
+						more = backend.hasReceiveMore();
+						
+						// Broker it
+						frontend.sendMsg(msg, { if (more) SNDMORE else null; } );
+					}
+				}
+			} catch (e:ZMQException) {
+				if (ZMQ.isInterrupted()) {
+					break;
+				}
+				// Handle other errors
+				trace("ZMQException #:" + e.errNo + ", str:" + e.str());
+				trace (Stack.toString(Stack.exceptionStack()));
+				
+			}
+
+		}
+		
+	}
+	public static function main() {		
+		var context:ZMQContext = ZMQContext.instance();
+		
+		Lib.println ("** MTServer (see: http://zguide.zeromq.org/page:all#Multithreading-with-MQ)");
+		
+		// Socket to talk to clients
+		var clients:ZMQSocket = context.socket(ZMQ_ROUTER);
+		clients.bind ("tcp://*:5556");
+		
+		// Socket to talk to workers
+		var workers:ZMQSocket = context.socket(ZMQ_DEALER);
+		
+#if (neko || cpp)        
+		workers.bind ("inproc://workers");
+        
+		// Launch worker thread pool
+		var workerThreads:List<Thread> = new List<Thread>();
+		for (thread_nbr in 0 ... 5) {
+			workerThreads.add(Thread.create(worker));
+		}
+#elseif php
+		workers.bind ("ipc://workers.ipc");
+
+        // Launch pool of worker processes, due to php's lack of thread support
+        // See: https://github.com/imatix/zguide/blob/master/examples/PHP/mtserver.php
+        for (thread_nbr in 0 ... 5) {
+            untyped __php__('
+                $pid = pcntl_fork();
+                if ($pid == 0) {
+                    // Running in child process
+                    worker();
+                    exit();
+                }');
+        }
+#end        
+		// Invoke request / reply broker (aka QUEUE device) to connect clients to workers
+		queueDevice(context, clients, workers);
+		
+		// Close up shop
+		clients.close();
+		workers.close();
+		context.term();
+	}
+}

--- a/examples/Haxe/PSEnvPub.hx
+++ b/examples/Haxe/PSEnvPub.hx
@@ -1,0 +1,42 @@
+package ;
+import haxe.io.Bytes;
+import neko.Lib;
+import neko.Sys;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQException;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Pubsub envelope publisher
+ * 
+ * See: http://zguide.zeromq.org/page:all#Pub-sub-Message-Envelopes
+ * 
+ * Use with PSEnvSub
+ */
+class PSEnvPub 
+{
+
+    public static function main() {
+        var context:ZMQContext = ZMQContext.instance();
+        
+        Lib.println("** PSEnvPub (see: http://zguide.zeromq.org/page:all#Pub-sub-Message-Envelopes)");
+        
+        var publisher:ZMQSocket = context.socket(ZMQ_PUB);
+        publisher.bind("tcp://*:5563");
+        
+        ZMQ.catchSignals();
+        
+
+        while (true) {
+            publisher.sendMsg(Bytes.ofString("A"), SNDMORE);
+            publisher.sendMsg(Bytes.ofString("We don't want to see this"));
+            publisher.sendMsg(Bytes.ofString("B"), SNDMORE);
+            publisher.sendMsg(Bytes.ofString("We would like to see this"));
+            Sys.sleep(1.0);
+        }
+        // We never get here but clean up anyhow
+        publisher.close();
+        context.term();
+    }
+}

--- a/examples/Haxe/PSEnvSub.hx
+++ b/examples/Haxe/PSEnvSub.hx
@@ -1,0 +1,37 @@
+package ;
+import haxe.io.Bytes;
+import neko.Lib;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Pubsub envelope subscriber
+ * 
+ * See: http://zguide.zeromq.org/page:all#Pub-sub-Message-Envelopes
+ * 
+ * Use with PSEnvPub
+ */
+class PSEnvSub 
+{
+
+    public static function main() {
+        var context:ZMQContext = ZMQContext.instance();
+        
+        Lib.println("** PSEnvSub (see: http://zguide.zeromq.org/page:all#Pub-sub-Message-Envelopes)");
+        
+        var subscriber:ZMQSocket = context.socket(ZMQ_SUB);
+        subscriber.connect("tcp://127.0.0.1:5563");
+        subscriber.setsockopt(ZMQ_SUBSCRIBE, Bytes.ofString("B"));
+        
+        while (true) {
+            var msgAddress:Bytes = subscriber.recvMsg();
+            // Read message contents
+            var msgContent:Bytes = subscriber.recvMsg();
+            trace (msgAddress.toString() + " " + msgContent.toString() + "\n");
+        }
+        // We never get here but clean up anyway
+        subscriber.close();
+        context.term();
+    }
+}

--- a/examples/Haxe/README
+++ b/examples/Haxe/README
@@ -1,0 +1,6 @@
+Examples in haXe
+For LICENSE in examples directory
+
+Run.hx provides an entry class to run any of the haXe examples.
+Look at the provided .hxml files for compilation examples, eg:
+haxe buildMac64.hxml

--- a/examples/Haxe/RrBroker.hx
+++ b/examples/Haxe/RrBroker.hx
@@ -1,0 +1,77 @@
+package ;
+import haxe.io.Bytes;
+import haxe.Stack;
+import neko.Lib;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQPoller;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Simple request-reply broker
+ * 
+ * Use with RrClient.hx and RrServer.hx
+ */
+class RrBroker 
+{
+
+    public static function main() {
+        var context:ZMQContext = ZMQContext.instance();
+        
+		Lib.println("** RrBroker (see: http://zguide.zeromq.org/page:all#A-Request-Reply-Broker)");
+        
+        var frontend:ZMQSocket = context.socket(ZMQ_ROUTER);
+        var backend:ZMQSocket = context.socket(ZMQ_DEALER);
+        frontend.bind("tcp://*:5559");
+        backend.bind("tcp://*:5560");
+        
+        Lib.println("Launch and connect broker.");
+        
+        // Initialise poll set
+        var items:ZMQPoller = context.poller();
+        items.registerSocket(frontend, ZMQ.ZMQ_POLLIN());
+        items.registerSocket(backend, ZMQ.ZMQ_POLLIN());
+        
+        var more = false;
+        var msgBytes:Bytes;
+        
+        ZMQ.catchSignals();
+        
+        while (true) {
+            try {
+                items.poll();
+                if (items.pollin(1)) {
+                    while (true) {
+                        // receive message
+                        msgBytes = frontend.recvMsg();
+                        more = frontend.hasReceiveMore();
+                        // broker it to backend
+                        backend.sendMsg(msgBytes, { if (more) SNDMORE else null; } );
+                        if (!more) break;
+                    }
+                }
+                
+                if (items.pollin(2)) {
+                    while (true) {
+                        // receive message
+                        msgBytes = backend.recvMsg();
+                        more = backend.hasReceiveMore();
+                        // broker it to frontend
+                        frontend.sendMsg(msgBytes, { if (more) SNDMORE else null; } );
+                        if (!more) break;
+                    }
+                }
+            } catch (e:ZMQException) {
+				if (ZMQ.isInterrupted()) {
+					break;
+				}
+				// Handle other errors
+				trace("ZMQException #:" + e.errNo + ", str:" + e.str());
+				trace (Stack.toString(Stack.exceptionStack()));
+			}
+        }
+        frontend.close();
+        backend.close();
+        context.term();
+    }
+}

--- a/examples/Haxe/RrClient.hx
+++ b/examples/Haxe/RrClient.hx
@@ -1,0 +1,47 @@
+package ;
+
+import neko.Lib;
+import haxe.io.Bytes;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+
+/**
+ * Hello World Client
+ * Connects REQ socket to tcp://localhost:5559
+ * Sends "Hello" to server, expects "World" back
+ * 
+ * See: http://zguide.zeromq.org/page:all#A-Request-Reply-Broker
+ * 
+ * Use with RrServer and RrBroker
+ */
+class RrClient 
+{
+
+    public static function main() {
+        var context:ZMQContext = ZMQContext.instance();
+        
+		Lib.println("** RrClient (see: http://zguide.zeromq.org/page:all#A-Request-Reply-Broker)");
+
+		var requester:ZMQSocket = context.socket(ZMQ_REQ);
+		requester.connect ("tcp://localhost:5559");
+		
+        Lib.println ("Launch and connect client.");
+        
+		// Do 10 requests, waiting each time for a response
+		for (i in 0...10) {
+			var requestString = "Hello ";
+			// Send the message
+			requester.sendMsg(Bytes.ofString(requestString));
+			
+			// Wait for the reply
+			var msg:Bytes = requester.recvMsg();
+			
+			Lib.println("Received reply " + i + ": [" + msg.toString() + "]");
+			
+		}
+		
+		// Shut down socket and context
+		requester.close();
+		context.term();
+    }
+}

--- a/examples/Haxe/RrServer.hx
+++ b/examples/Haxe/RrServer.hx
@@ -1,0 +1,64 @@
+package ;
+
+import haxe.io.Bytes;
+import haxe.Stack;
+import neko.Lib;
+import neko.Sys;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQException;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Hello World server in Haxe
+ * Binds REP to tcp://*:5560
+ * Expects "Hello" from client, replies with "World"
+ * Use with RrClient.hx and RrBroker.hx
+ * 
+ */
+class RrServer 
+{
+
+	public static function main() {
+		
+		var context:ZMQContext = ZMQContext.instance();
+
+		Lib.println("** RrServer (see: http://zguide.zeromq.org/page:all#A-Request-Reply-Broker)");
+
+        // Socket to talk to clients
+		var responder:ZMQSocket = context.socket(ZMQ_REP);
+		responder.connect("tcp://localhost:5560");
+		
+        Lib.println("Launch and connect server.");
+        
+        ZMQ.catchSignals();
+        
+        while (true) {
+            
+            try {
+                // Wait for next request from client
+                var request:Bytes = responder.recvMsg();
+                
+                trace ("Received request:" + request.toString());
+                
+                // Do some work
+                Sys.sleep(1);
+                
+                // Send reply back to client
+                responder.sendMsg(Bytes.ofString("World"));
+            } catch (e:ZMQException) {
+				if (ZMQ.isInterrupted()) {
+					break;
+				}
+				// Handle other errors
+				trace("ZMQException #:" + e.errNo + ", str:" + e.str());
+				trace (Stack.toString(Stack.exceptionStack()));
+			}
+
+        }
+		responder.close();
+		context.term();
+		
+	}
+	
+}

--- a/examples/Haxe/Run.hx
+++ b/examples/Haxe/Run.hx
@@ -1,0 +1,136 @@
+package ;
+
+import neko.io.File;
+import neko.io.FileInput;
+import neko.io.Process;
+import neko.Lib;
+import neko.Sys;
+
+import org.zeromq.guide.HelloWorldClient;
+import org.zeromq.guide.HelloWorldServer;
+import org.zeromq.guide.WUClient;
+import org.zeromq.guide.WUServer;
+import org.zeromq.guide.TaskVent;
+import org.zeromq.guide.TaskWork;
+import org.zeromq.guide.TaskSink;
+import org.zeromq.guide.Interrupt;
+
+/**
+ * Main class that allows any of the implemented Haxe guide programs to run
+ */
+class Run 
+{
+
+	public static function main() 
+	{
+		var selection:Int;
+		
+		Lib.println("** HaXe ZeroMQ Guide program launcher **");
+		
+		if (Sys.args().length > 0) {
+			selection = Std.parseInt(Sys.args()[0]);
+		} else {
+			Lib.println("");
+			Lib.println("Programs:");
+			
+			Lib.println("1. HelloWorldClient");
+			Lib.println("2. HelloWorldServer");
+			Lib.println("");
+			Lib.println("3. WUClient");
+			Lib.println("4. WUServer");
+			Lib.println("");
+			Lib.println("5. TaskVent");
+			Lib.println("6. TaskWork");
+			Lib.println("7. TaskSink");
+			Lib.println("");
+			Lib.println("11. Interrupt (** Doesn't work on Windows!)");
+			Lib.println("");
+			Lib.println("12. MTServer (use with 1. HelloWorldClient)");
+			Lib.println("");
+			Lib.println("13. TaskWork2 (use with 5. TaskVent and 14. TaskSink2)");
+            Lib.println("14. TaskSink2 (use with 5. TaskVent and 13. TaskWork2)");
+			Lib.println("");
+			Lib.println("15. WUProxy (use with 4. WUServer)");
+			Lib.println("");
+			Lib.println("16. RrClient");
+			Lib.println("17. RrBroker");
+			Lib.println("18. RrServer");
+			Lib.println("");
+			Lib.println("19. MTRelay");
+            Lib.println("");
+            Lib.println("20. SyncPub");
+            Lib.println("21. SyncSub");
+            Lib.println("");
+            Lib.println("22. PSEnvPub");
+            Lib.println("23. PSEnvSub");
+            Lib.println("");
+            Lib.println("24. DuraPub");
+            Lib.println("25. DuraSub");
+            Lib.println("26. DuraPub2");
+			
+			do {
+				Lib.print("Type number followed by Enter key, or q to quit: ");
+				var f:FileInput = File.stdin();
+				var str:String = f.readLine();
+		
+				if (str.toLowerCase() == "q") {
+					return;
+				}
+				
+				selection = Std.parseInt(str);
+			} while (selection == null);
+		}
+		
+		switch (selection) {
+			case 1:
+				HelloWorldClient.main();
+			case 2:
+				HelloWorldServer.main();
+			case 3:
+				WUClient.main();
+			case 4:
+				WUServer.main();
+			case 5:
+				TaskVent.main();
+			case 6:
+				TaskWork.main();
+			case 7:
+				TaskSink.main();
+			case 11:
+				Interrupt.main();
+			case 12:
+				MTServer.main();
+            case 13:
+                TaskWork2.main();
+            case 14:
+                TaskSink2.main();
+            case 15:
+                WUProxy.main();
+            case 16:
+                RrClient.main();
+            case 17:
+                RrBroker.main();
+            case 18:
+                RrServer.main();
+            case 19:
+                MTRelay.main();
+            case 20:
+                SyncPub.main();
+            case 21:
+                SyncSub.main();
+            case 22:
+                PSEnvPub.main();
+            case 23:
+                PSEnvSub.main();
+            case 24:
+                DuraPub.main();
+            case 25:
+                DuraSub.main();
+            case 26:
+                DuraPub2.main();
+			default:
+			Lib.println ("Unknown program number ... exiting");
+		}
+	}
+	
+}

--- a/examples/Haxe/SyncPub.hx
+++ b/examples/Haxe/SyncPub.hx
@@ -1,0 +1,52 @@
+package ;
+import haxe.io.Bytes;
+import neko.Lib;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Synchronised publisher
+ * 
+ * See: http://zguide.zeromq.org/page:all#Node-Coordination
+ * 
+ * Use with SyncSub.hx
+ */
+class SyncPub 
+{
+    static inline var SUBSCRIBERS_EXPECTED = 10;
+    
+    public static function main() {
+        var context:ZMQContext = ZMQContext.instance();
+        Lib.println("** SyncPub (see: http://zguide.zeromq.org/page:all#Node-Coordination)");
+        
+        // Socket to talk to clients
+        var publisher:ZMQSocket = context.socket(ZMQ_PUB);
+        publisher.bind("tcp://*:5561");
+        
+        // Socket to receive signals
+        var syncService:ZMQSocket = context.socket(ZMQ_REP);
+        syncService.bind("tcp://*:5562");
+        
+        // get synchronisation from subscribers
+        var subscribers = 0;
+        while (subscribers < SUBSCRIBERS_EXPECTED) {
+            // wait for synchronisation request
+            var msgBytes = syncService.recvMsg();
+            
+            // send synchronisation reply
+            syncService.sendMsg(Bytes.ofString(""));
+            subscribers++;
+        }
+        
+        // Now broadcast exactly 1m updates followed by END
+        for (update_nbr in 0 ... 1000000) {
+            publisher.sendMsg(Bytes.ofString("Rhubarb"));
+        }
+        publisher.sendMsg(Bytes.ofString("END"));
+        
+        publisher.close();
+        syncService.close();
+        context.term();
+    }
+}

--- a/examples/Haxe/SyncSub.hx
+++ b/examples/Haxe/SyncSub.hx
@@ -1,0 +1,59 @@
+package ;
+
+import neko.Lib;
+import haxe.io.Bytes;
+import neko.Sys;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Synchronised subscriber
+ * 
+ * See: http://zguide.zeromq.org/page:all#Node-Coordination 
+ * 
+ * Use with SyncPub.hx
+ */
+class SyncSub 
+{
+
+    public static function main() {
+        var context:ZMQContext = ZMQContext.instance();
+        
+        Lib.println("** SyncSub (see: http://zguide.zeromq.org/page:all#Node-Coordination)");
+        
+        // First connect our subscriber socket
+        var subscriber:ZMQSocket = context.socket(ZMQ_SUB);
+        subscriber.connect("tcp://127.0.0.1:5561");
+        subscriber.setsockopt(ZMQ_SUBSCRIBE, Bytes.ofString(""));
+        
+        // 0MQ is so fast, we need to wait a little while
+        Sys.sleep(1.0);
+        
+        // Second, synchronise with publisher
+        var syncClient:ZMQSocket = context.socket(ZMQ_REQ);
+        syncClient.connect("tcp://127.0.0.1:5562");
+        
+        // Send a synchronisation request
+        syncClient.sendMsg(Bytes.ofString(""));
+        
+        // Wait for a synchronisation reply
+        var msgBytes:Bytes = syncClient.recvMsg();
+        
+        // Third, get our updates and report how many we got
+        var update_nbr = 0;
+        while (true) {
+            msgBytes = subscriber.recvMsg();
+            if (msgBytes.toString() == "END") {
+                break;
+            }
+            msgBytes = null;
+            update_nbr++;
+        }
+        Lib.println("Received " + update_nbr + " updates\n");
+        
+        subscriber.close();
+        syncClient.close();
+        context.term();
+    }
+}

--- a/examples/Haxe/TaskSink.hx
+++ b/examples/Haxe/TaskSink.hx
@@ -1,0 +1,56 @@
+package ;
+
+import haxe.io.Bytes;
+import neko.Lib;
+import neko.Sys;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Task sink in Haxe
+ * Binds PULL request socket to tcp://localhost:5558
+ * Collects results from workers via this socket
+ * 
+ * See: http://zguide.zeromq.org/page:all#Divide-and-Conquer
+ * 
+ * Based on http://zguide.zeromq.org/java:tasksink
+ * 
+ * Use with TaskVent.hx and TaskWork.hx
+ */
+class TaskSink 
+{
+
+	public static function main() {
+		var context:ZMQContext = ZMQContext.instance();
+
+		Lib.println("** TaskSink (see: http://zguide.zeromq.org/page:all#Divide-and-Conquer)");
+		
+		// Socket to receive messages on
+		var receiver:ZMQSocket = context.socket(ZMQ_PULL);
+		receiver.bind("tcp://127.0.0.1:5558");
+		
+		// Wait for start of batch
+		var msgString = StringTools.trim(receiver.recvMsg().toString());
+		
+		// Start our clock now
+		var tStart = Sys.time();
+		
+		// Process 100 messages
+		var task_nbr:Int;
+		for (task_nbr in 0 ... 100) {
+			msgString = StringTools.trim(receiver.recvMsg().toString());
+			if (task_nbr % 10 == 0) {
+				Lib.println(":");		// Print a ":" every 10 messages
+			} else {
+				Lib.print(".");
+			}
+		}
+		// Calculate and report duation of batch
+		var tEnd = Sys.time();
+		Lib.println("Total elapsed time: " + Math.ceil((tEnd - tStart) * 1000) + " msec");
+		
+		receiver.close();
+		context.term();
+	}
+}

--- a/examples/Haxe/TaskSink2.hx
+++ b/examples/Haxe/TaskSink2.hx
@@ -1,0 +1,67 @@
+package ;
+
+import haxe.io.Bytes;
+import neko.Lib;
+import neko.Sys;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Parallel Task sink with kil signalling in Haxe
+ * Binds PULL request socket to tcp://localhost:5558
+ * Collects results from workers via this socket
+ * 
+ * See: http://zguide.zeromq.org/page:all#Handling-Errors-and-ETERM
+ * 
+ * Based on http://zguide.zeromq.org/cs:tasksink2
+ * 
+ * Use with TaskVent.hx and TaskWork2.hx
+ */
+class TaskSink2
+{
+
+	public static function main() {
+		var context:ZMQContext = ZMQContext.instance();
+
+		Lib.println("** TaskSink2 (see: http://zguide.zeromq.org/page:all#Handling-Errors-and-ETERM)");
+		
+		// Socket to receive messages on
+		var receiver:ZMQSocket = context.socket(ZMQ_PULL);
+		receiver.bind("tcp://127.0.0.1:5558");
+		
+        // Socket to send control messages to workers
+        var controller:ZMQSocket = context.socket(ZMQ_PUB);
+        controller.bind("tcp://127.0.0.1:5559");
+        
+		// Wait for start of batch
+		var msgString = StringTools.trim(receiver.recvMsg().toString());
+		
+		// Start our clock now
+		var tStart = Sys.time();
+		
+		// Process 100 messages
+		var task_nbr:Int;
+		for (task_nbr in 0 ... 100) {
+			msgString = StringTools.trim(receiver.recvMsg().toString());
+			if (task_nbr % 10 == 0) {
+				Lib.println(":");		// Print a ":" every 10 messages
+			} else {
+				Lib.print(".");
+			}
+		}
+        
+		// Calculate and report duation of batch
+		var tEnd = Sys.time();
+		Lib.println("Total elapsed time: " + Math.ceil((tEnd - tStart) * 1000) + " msec");
+		
+        // Send kill signal to workers
+        controller.sendMsg(Bytes.ofString("KILL"));
+        Sys.sleep(1.0); // Give 0MQ time to deliver
+        
+        // Shut down
+		receiver.close();
+        controller.close();
+		context.term();
+	}
+}

--- a/examples/Haxe/TaskVent.hx
+++ b/examples/Haxe/TaskVent.hx
@@ -1,0 +1,65 @@
+package ;
+
+import haxe.io.Bytes;
+import haxe.Stack;
+import neko.Lib;
+import neko.io.File;
+import neko.io.FileInput;
+import neko.Sys;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQException;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Task ventilator in Haxe
+ * Binds PUSH socket to tcp://localhost:5557
+ * Sends batch of tasks to workers via that socket.
+ * 
+ * Based on code from: http://zguide.zeromq.org/java:taskvent
+ * 
+ * Use with TaskWork.hx and TaskSink.hx
+ */
+class TaskVent 
+{
+
+	public static function main() {
+		
+		try {
+			var context:ZMQContext = ZMQContext.instance();
+			var sender:ZMQSocket = context.socket(ZMQ_PUSH);
+
+			Lib.println("** TaskVent (see: http://zguide.zeromq.org/page:all#Divide-and-Conquer)");
+			
+			sender.bind("tcp://127.0.0.1:5557");
+			
+			Lib.println("Press Enter when the workers are ready: ");
+			var f:FileInput = File.stdin();
+			var str:String = f.readLine();
+			Lib.println("Sending tasks to workers ...\n");
+			
+			// The first message is "0" and signals starts of batch
+			sender.sendMsg(Bytes.ofString("0"));
+			
+			// Send 100 tasks
+			var totalMsec:Int = 0;		// Total expected cost in msec
+			for (task_nbr in 0 ... 100) {
+				var workload = Std.random(100) + 1;	// Generates 1 to 100 msecs
+				totalMsec += workload;
+				Lib.print(workload + ".");
+				sender.sendMsg(Bytes.ofString(Std.string(workload)));
+			}
+			Lib.println("Total expected cost: " + totalMsec + " msec");
+			
+			// Give 0MQ time to deliver
+			Sys.sleep(1);
+
+			sender.close();
+			context.term();
+		} catch (e:ZMQException) {
+			trace("ZMQException #:" + ZMQ.errNoToErrorType(e.errNo) + ", str:" + e.str());
+			trace (Stack.toString(Stack.exceptionStack()));
+				
+		}
+	}
+}

--- a/examples/Haxe/TaskWork.hx
+++ b/examples/Haxe/TaskWork.hx
@@ -1,0 +1,54 @@
+package ;
+
+import haxe.io.Bytes;
+import neko.Lib;
+import neko.Sys;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Task worker in Haxe
+ * Connects PULL socket to tcp://localhost:5557
+ * Collects workloads from ventilator via that socket
+ * Connects PUSH socket to tcp://localhost:5558
+ * Sends results to sink via that socket
+ * 
+ * See: http://zguide.zeromq.org/page:all#Divide-and-Conquer
+ * 
+ * Based on code from: http://zguide.zeromq.org/java:taskwork
+ * 
+ * Use with TaskVent.hx and TaskSink.hx
+ */
+class TaskWork 
+{
+
+	public static function main() {
+		var context:ZMQContext = ZMQContext.instance();
+
+		Lib.println("** TaskWork (see: http://zguide.zeromq.org/page:all#Divide-and-Conquer)");
+		
+		// Socket to receive messages on
+		var receiver:ZMQSocket = context.socket(ZMQ_PULL);
+		receiver.connect("tcp://127.0.0.1:5557");
+
+		// Socket to send messages to
+		var sender:ZMQSocket = context.socket(ZMQ_PUSH);
+		sender.connect("tcp://127.0.0.1:5558");
+		
+		// Process tasks forever
+		while (true) {
+			var msgString = StringTools.trim(receiver.recvMsg().toString());
+			var sec:Float = Std.parseFloat(msgString) / 1000.0;
+			Lib.print(msgString + ".");
+			
+			// Do the work
+			Sys.sleep(sec);
+			
+			// Send results to sink
+			sender.sendMsg(Bytes.ofString(""));
+		}
+		
+		
+	}
+}

--- a/examples/Haxe/TaskWork2.hx
+++ b/examples/Haxe/TaskWork2.hx
@@ -1,0 +1,73 @@
+package ;
+
+import haxe.io.Bytes;
+import neko.Lib;
+import neko.Sys;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQPoller;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Parallel Task worker with kill signalling in Haxe
+ * Connects PULL socket to tcp://localhost:5557
+ * Collects workloads from ventilator via that socket
+ * Connects PUSH socket to tcp://localhost:5558
+ * Sends results to sink via that socket
+ * 
+ * See: http://zguide.zeromq.org/page:all#Handling-Errors-and-ETERM
+ * 
+ * Based on code from: http://zguide.zeromq.org/java:taskwork2
+ */
+class TaskWork2
+{
+
+	public static function main() {
+		var context:ZMQContext = ZMQContext.instance();
+
+		Lib.println("** TaskWork2 (see: http://zguide.zeromq.org/page:all#Handling-Errors-and-ETERM)");
+		
+		// Socket to receive messages on
+		var receiver:ZMQSocket = context.socket(ZMQ_PULL);
+		receiver.connect("tcp://127.0.0.1:5557");
+
+		// Socket to send messages to
+		var sender:ZMQSocket = context.socket(ZMQ_PUSH);
+		sender.connect("tcp://127.0.0.1:5558");
+		
+        // Socket to receive controller messages from
+        var controller:ZMQSocket = context.socket(ZMQ_SUB);
+        controller.connect("tcp://127.0.0.1:5559");
+        controller.setsockopt(ZMQ_SUBSCRIBE, Bytes.ofString(""));
+        
+        var items:ZMQPoller = context.poller();
+        items.registerSocket(receiver, ZMQ.ZMQ_POLLIN());
+        items.registerSocket(controller, ZMQ.ZMQ_POLLIN());
+        
+        var msgString:String;
+        
+		// Process tasks forever
+		while (true) {
+            var numSocks = items.poll();
+            if (items.pollin(1)) {
+                // receiver socket has events
+                msgString = StringTools.trim(receiver.recvMsg().toString());
+                var sec:Float = Std.parseFloat(msgString) / 1000.0;
+                Lib.print(msgString + ".");
+                
+                // Do the work
+                Sys.sleep(sec);
+                
+                // Send results to sink
+                sender.sendMsg(Bytes.ofString(""));    
+            }
+			if (items.pollin(2)) {
+                break; // Exit loop
+            }
+		}
+        receiver.close();
+        sender.close();
+        controller.close();
+        context.term();
+	}
+}

--- a/examples/Haxe/WUClient.hx
+++ b/examples/Haxe/WUClient.hx
@@ -1,0 +1,72 @@
+package ;
+import haxe.io.Bytes;
+import neko.Lib;
+import neko.Sys;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQException;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Weather update client in Haxe
+ * Connects SUB socket to tcp://localhost:5556
+ * Collects weather updates and finds average temp in zipcode
+ * 
+ * Use optional argument to specify zip code (in range 1 to 100000)
+ * 
+ * See: http://zguide.zeromq.org/page:all#Getting-the-Message-Out
+ * 
+ * Use with WUServer.hx
+ */
+class WUClient 
+{
+
+	public static function main() {
+		var context:ZMQContext = ZMQContext.instance();
+		
+		Lib.println("** WUClient (see: http://zguide.zeromq.org/page:all#Getting-the-Message-Out)");
+		
+		// Socket to talk to server
+		trace ("Collecting updates from weather server...");
+		var subscriber:ZMQSocket = context.socket(ZMQ_SUB);
+		subscriber.setsockopt(ZMQ_LINGER, 0);	 // Don't block when closing socket at end
+		
+		subscriber.connect("tcp://localhost:5556");
+		
+		// Subscribe to zipcode, default in NYC, 10001
+		var filter:String = 
+			if (Sys.args().length > 0) {
+				Sys.args()[0];
+			} else {
+				"10001";
+			};
+				
+		try {
+			subscriber.setsockopt(ZMQ_SUBSCRIBE, Bytes.ofString(filter));
+		} catch (e:ZMQException) {
+			trace (e.str());
+		}
+		
+		// Process 100 updates
+		var update_nbr = 0;
+		var total_temp:Int = 0;
+		for (update_nbr in 0...100) {
+			var msg:Bytes = subscriber.recvMsg();
+			trace (update_nbr+ ". Received: " + msg.toString());
+			
+			var zipcode, temperature, relhumidity;
+			
+			var sscanf:Array<String> = msg.toString().split(" ");
+			zipcode = sscanf[0];
+			temperature = sscanf[1];
+			relhumidity = sscanf[2];
+			total_temp += Std.parseInt(temperature);
+			
+		}
+		trace ("Average temperature for zipcode " + filter + " was " + total_temp / 100);
+		
+		// Close gracefully
+		subscriber.close();
+		context.term();
+	}
+}

--- a/examples/Haxe/WUProxy.hx
+++ b/examples/Haxe/WUProxy.hx
@@ -1,0 +1,67 @@
+package ;
+
+import haxe.io.Bytes;
+import haxe.Stack;
+
+import neko.Lib;
+
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Weather proxy device.
+ * 
+ * See: http://zguide.zeromq.org/page:all#A-Publish-Subscribe-Proxy-Server
+ * 
+ * Use with WUClient and WUServer
+ */
+class WUProxy 
+{
+
+    public static function main() {
+        var context:ZMQContext = ZMQContext.instance();
+		Lib.println("** WUProxy (see: http://zguide.zeromq.org/page:all#A-Publish-Subscribe-Proxy-Server)");
+        
+        // This is where the weather service sits
+        var frontend:ZMQSocket = context.socket(ZMQ_SUB);
+        frontend.connect("tcp://localhost:5556");
+        
+        // This is our public endpoint for subscribers
+        var backend:ZMQSocket = context.socket(ZMQ_PUB);
+        backend.bind("tcp://10.1.1.0:8100");
+        
+        // Subscribe on everything
+        frontend.setsockopt(ZMQ_SUBSCRIBE, Bytes.ofString(""));
+        
+        var more = false;
+        var msgBytes:Bytes;
+        
+        ZMQ.catchSignals();
+        
+        var stopped = false;
+        while (!stopped) {
+            try {
+                msgBytes = frontend.recvMsg();
+                more = frontend.hasReceiveMore();
+                
+                // proxy it
+                backend.sendMsg(msgBytes, { if (more) SNDMORE else null; } );
+                if (!more) {
+                    stopped = true;
+                }
+ 			} catch (e:ZMQException) {
+				if (ZMQ.isInterrupted()) {
+					stopped = true;
+				} else {
+                    // Handle other errors
+                    trace("ZMQException #:" + e.errNo + ", str:" + e.str());
+                    trace (Stack.toString(Stack.exceptionStack()));
+                }
+			}
+       }
+       frontend.close();
+       backend.close();
+       context.term();
+    }
+}

--- a/examples/Haxe/WUServer.hx
+++ b/examples/Haxe/WUServer.hx
@@ -1,0 +1,40 @@
+package ;
+import haxe.io.Bytes;
+import neko.Lib;
+import org.zeromq.ZMQ;
+import org.zeromq.ZMQContext;
+import org.zeromq.ZMQSocket;
+
+/**
+ * Weather update server in Haxe
+ * Binds PUB socket to tcp://*:5556
+ * Publishes random weather updates
+ * 
+ * See: http://zguide.zeromq.org/page:all#Getting-the-Message-Out
+ * 
+ * Use with WUClient.hx
+ */
+class WUServer 
+{
+
+	public static function main() {
+		var context:ZMQContext = ZMQContext.instance();
+		
+		Lib.println("** WUServer (see: http://zguide.zeromq.org/page:all#Getting-the-Message-Out)");
+
+		var publisher:ZMQSocket = context.socket(ZMQ_PUB);
+		publisher.bind("tcp://127.0.0.1:5556");
+		
+		while (true) {
+			// Get values that will fool the boss
+			var zipcode, temperature, relhumidity;           
+			zipcode = Std.random(100000) + 1;
+			temperature = Std.random(215) - 80 + 1;
+			relhumidity = Std.random(50) + 10 + 1;
+			
+			// Send message to all subscribers
+			var update:String = zipcode + " " + temperature + " " + relhumidity;
+			publisher.sendMsg(Bytes.ofString(update));
+		}
+	}
+}

--- a/examples/Haxe/buildLinux.hxml
+++ b/examples/Haxe/buildLinux.hxml
@@ -1,0 +1,27 @@
+# Haxe build file
+# Build CPP guide target for Linux 32bit
+-cp .
+-cpp out-cpp/Linux
+-lib hxzmq
+-debug
+-D HXCPP_MULTI_THREADED
+--remap neko:cpp
+-main org.zeromq.guide.Run
+
+--next
+# Build neko guide target for Linux 32bit
+-cp .
+-neko out-neko/Linux/run-debug.n
+-lib hxzmq
+-debug
+-main org.zeromq.guide.Run
+
+# Build PHP guide target
+--next
+-cp .
+-php out-php/Linux
+-lib hxzmq
+-debug
+--remap neko:php
+-main org.zeromq.guide.Run
+

--- a/examples/Haxe/buildMac64.hxml
+++ b/examples/Haxe/buildMac64.hxml
@@ -1,0 +1,21 @@
+# Haxe build file
+# Build CPP guide target
+-cp .
+-cpp out-cpp/Mac64
+-lib hxzmq
+-debug
+-D HXCPP_M64
+-D HXCPP_MULTI_THREADED
+--remap neko:cpp
+-main org.zeromq.guide.Run
+
+# todo: Neko Mac0SX 64 bit target
+
+# Build PHP guide target
+--next
+-cp .
+-php out-php/Mac64
+-lib hzxmq
+-debug
+--remap neko:php
+-main org.zeromq.guide.Run

--- a/examples/Haxe/buildWindows.hxml
+++ b/examples/Haxe/buildWindows.hxml
@@ -1,0 +1,27 @@
+# Haxe build file
+# Builds Windows HXZMQ Guide code
+# Build CPP guide target
+-cp .
+-cpp out-cpp/Windows
+-lib hxzmq
+-debug
+-D HXCPP_MULTI_THREADED
+--remap neko:cpp
+-main org.zeromq.guide.Run
+--next
+# Build Neko guide target
+-cp .
+-neko out-neko/Windows/run-debug.n
+-lib hxzmq
+-debug
+-main org.zeromq.guide.Run
+
+# Build PHP guide target
+--next
+-cp .
+-php out-php/Windows
+-lib hxzmq
+-debug
+--remap neko:php
+-main org.zeromq.guide.Run
+


### PR DESCRIPTION
I would like to submit HaXe language examples for chapters one and two to be added to the ZeroMQ Guide.

It contains a new /examples/Haxe folder, holding haXe examples for chapters one and two using the lower-level ZMQxxxx.hx classes of the hxzmq language binding, illustrating an API closer to the core zeromq C functions.

Also includes:
1.   an additional Run.hx class which provides a single entry-point to compile and run any of the examples in one generated executable
2.   example haxe compilation hxml configuration files for Mac, Linux and Windows 

Note that I have not attempted to add haxe to any of the guide build files in the /bin folder, not knowing what would need to be added to where.
