### PR TITLE
Fixes to java examples

### DIFF
--- a/examples/Java/hwclient.java
+++ b/examples/Java/hwclient.java
@@ -7,7 +7,7 @@
 //
 import org.zeromq.ZMQ;
 
-public class HelloWorldClient{
+public class hwclient{
     public static void main(String[] args){
         //  Prepare our context and socket
         ZMQ.Context context = ZMQ.context(1);

--- a/examples/Java/hwserver.java
+++ b/examples/Java/hwserver.java
@@ -7,7 +7,7 @@
 //
 import org.zeromq.ZMQ;
 
-public class HelloWorldServer {
+public class hwserver {
     public static void main(String[] args) {
         //  Prepare our context and socket
         ZMQ.Context context = ZMQ.context(1);

--- a/examples/Java/lruqueue.java
+++ b/examples/Java/lruqueue.java
@@ -81,7 +81,7 @@ class WorkerThread extends Thread
 	}
 }
 
-public class LRUQueue {
+public class lruqueue {
 
 	public static void main(String[] args) {
 		Context context = ZMQ.context(1);

--- a/examples/Java/msgqueue.java
+++ b/examples/Java/msgqueue.java
@@ -9,7 +9,7 @@ import org.zeromq.ZMQQueue;
  * 
  * Christophe Huntzinger <chuntz@laposte.net>
  */
-public class MsgQueue{
+public class msgqueue{
 
 	public static void main (String[] args) {
 		//  Prepare our context and sockets

--- a/examples/Java/mspoller.java
+++ b/examples/Java/mspoller.java
@@ -22,8 +22,8 @@ public class mspoller {
 
 		//  Initialize poll set
 		ZMQ.Poller items = context.poller(2);
-		items.register(receiver, 0);
-		items.register(subscriber, 0);
+		items.register(receiver, ZMQ.Poller.POLLIN);
+		items.register(subscriber, ZMQ.Poller.POLLIN);
 
 		//  Process messages from both sockets
 		while (true) {

--- a/examples/Java/msreader.java
+++ b/examples/Java/msreader.java
@@ -21,11 +21,6 @@ public class msreader {
 		subscriber.connect("tcp://localhost:5556");
 		subscriber.subscribe("10001 ".getBytes());
 
-		//  Initialize poll set
-		ZMQ.Poller items = context.poller(2);
-		items.register(receiver, 0);
-		items.register(subscriber, 0);
-
 		//  Process messages from both sockets
 		//  We prioritize traffic from the task ventilator
 		while (true) {

--- a/examples/Java/mtrelay.java
+++ b/examples/Java/mtrelay.java
@@ -5,7 +5,7 @@
 //
 import org.zeromq.ZMQ;
 
-public class MultiThreadedRelay{
+public class mtrelay{
     public static void main(String[] args) {
         final ZMQ.Context context = ZMQ.context(1);
 

--- a/examples/Java/psenvpub.java
+++ b/examples/Java/psenvpub.java
@@ -24,12 +24,3 @@ public class psenvpub {
 
   }
 }
-e our context and publisher
-    ZMQ.Context context = ZMQ.context(1);
-    ZMQ.Socket publisher = context.socket(ZMQ.PUB);
-
-    publisher.bind("tcp://*:5563");
-    while (true) {
-      // Write two messages, each with an envelope and content
-      publisher.send("A".getBytes(), ZMQ.SNDMORE);
-      publisher.send("We do

--- a/examples/Java/rrbroker.java
+++ b/examples/Java/rrbroker.java
@@ -9,7 +9,7 @@ import org.zeromq.ZMQ.Socket;
  * Christophe Huntzinger <chuntz@laposte.net>
  *
  */
-public class RrBroker{
+public class rrbroker{
 	public static void main (String[] args) {
 		//  Prepare our context and sockets
 		Context context = ZMQ.context(1);

--- a/examples/Java/rrclient.java
+++ b/examples/Java/rrclient.java
@@ -9,7 +9,7 @@ import org.zeromq.ZMQ.Socket;
  * 
  * Christophe Huntzinger <chuntzin_at_wanadoo.fr>
  */
-public class RrClient{
+public class rrclient{
 	public static void main (String[] args) {
 		Context context = ZMQ.context(1);
 

--- a/examples/Java/rrserver.java
+++ b/examples/Java/rrserver.java
@@ -9,7 +9,7 @@ import org.zeromq.ZMQ.Socket;
  * 
  * Christophe Huntzinger <chuntzin_at_wanadoo.fr>
  */
-public class RrServer{
+public class rrserver{
 	public static void main (String[] args) {
 		Context context = ZMQ.context(1);
 

--- a/examples/Java/syncpub.java
+++ b/examples/Java/syncpub.java
@@ -8,7 +8,7 @@ import org.zeromq.ZMQ.Socket;
  * 
  * Christophe Huntzinger <chuntzin_at_wanadoo.fr>
  */
-public class SyncPub{
+public class syncpub{
 	/**
 	 * We wait for 10 subscribers
 	 */

--- a/examples/Java/syncsub.java
+++ b/examples/Java/syncsub.java
@@ -8,7 +8,7 @@ import org.zeromq.ZMQ.Socket;
  * Christophe Huntzinger <chuntzin_at_wanadoo.fr>
  *
  */
-public class SyncSub{
+public class syncsub{
 	public static void main (String[] args) {
 		Context context = ZMQ.context(1);
 

--- a/examples/Java/taskwork2.java
+++ b/examples/Java/taskwork2.java
@@ -22,8 +22,8 @@ public class taskwork2 {
 		controller.subscribe("".getBytes());
 
 		ZMQ.Poller items = context.poller(2);
-		items.register(receiver, 0);
-		items.register(controller, 0);
+		items.register(receiver, ZMQ.Poller.POLLIN);
+		items.register(controller, ZMQ.Poller.POLLIN);
 
 		while (true) {
 			if (items.pollin(0)) {

--- a/examples/Java/version.java
+++ b/examples/Java/version.java
@@ -4,11 +4,11 @@ import org.zeromq.ZMQ;
 public class version
 {
 
-  public static void main ( final String[] args )
+  public static void main(final String[] args)
   {
-    System.out.println ( String.format ( "Version string: %s, Version int: %d", 
-                                         ZMQ.getVersionString (),
-                                         ZMQ.getFullVersion () ) );
+    System.out.println(String.format("Version string: %s, Version int: %d",
+        ZMQ.getVersionString(),
+        ZMQ.getFullVersion()));
   }
 
 }

--- a/examples/Java/wuproxy.java
+++ b/examples/Java/wuproxy.java
@@ -8,7 +8,7 @@ import org.zeromq.ZMQ.Socket;
  * 
  * Christophe Huntzinger <chuntz@laposte.net>
  */
-public class WuProxy{
+public class wuproxy{
 
 	public static void main (String[] args) {
 		//  Prepare our context and sockets


### PR DESCRIPTION
Java requires the names of the main classes to be the same as the file name (Case sensitive). There were some examples of using Poller.register(socket, 0). This was causing headaches when people use the poller example and then it breaks.
