### PR TITLE
fixed workers not purged according to spec in Majordomo example (all languages)

### DIFF
--- a/examples/C++/mdbroker.cpp
+++ b/examples/C++/mdbroker.cpp
@@ -129,8 +129,7 @@ public:
    }
 
    //  ---------------------------------------------------------------------
-   //  Delete any idle workers that haven't pinged us in a while. Workers
-   //  are oldest to most recent, so we stop at the first alive worker.
+   //  Delete any idle workers that haven't pinged us in a while.
 
    void
    purge_workers ()
@@ -138,7 +137,7 @@ public:
        worker * wrk = m_waiting.size()>0 ? m_waiting.front() : 0;
        while (wrk) {
            if (!wrk->expired ()) {
-               break;              //  Worker is alive, we're done here
+               continue;              //  Worker is alive, we're done here
            }
            if (m_verbose) {
                s_console ("I: deleting expired worker: %s",

--- a/examples/C/mdbroker.c
+++ b/examples/C/mdbroker.c
@@ -195,8 +195,7 @@ s_broker_bind (broker_t *self, char *endpoint)
 }
 
 //  ---------------------------------------------------------------------
-//  Delete any idle workers that haven't pinged us in a while. Workers
-//  are oldest to most recent, so we stop at the first alive worker.
+//  Delete any idle workers that haven't pinged us in a while.
 
 static void
 s_broker_purge_workers (broker_t *self)
@@ -204,7 +203,7 @@ s_broker_purge_workers (broker_t *self)
     worker_t *worker = (worker_t *) zlist_first (self->waiting);
     while (worker) {
         if (zclock_time () < worker->expiry)
-            break;              //  Worker is alive, we're done here
+            continue;              //  Worker is alive, we're done here
         if (self->verbose)
             zclock_log ("I: deleting expired worker: %s",
                 worker->identity);

--- a/examples/Lua/mdbroker.lua
+++ b/examples/Lua/mdbroker.lua
@@ -82,21 +82,19 @@ function broker_mt:bind(endpoint)
 end
 
 --  ---------------------------------------------------------------------
---  Delete any idle workers that haven't pinged us in a while. Workers
---  are oldest to most recent, so we stop at the first alive worker.
+--  Delete any idle workers that haven't pinged us in a while.
 
 function broker_mt:purge_workers()
     local waiting = self.waiting
     for n=1,#waiting do
         local worker = waiting[n]
-        if (not worker:expired()) then
-            return             --  Worker is alive, we're done here
-        end
-        if (self.verbose) then
-            s_console("I: deleting expired worker: %s", worker.identity)
-        end
+        if (worker:expired()) then
+            if (self.verbose) then
+                s_console("I: deleting expired worker: %s", worker.identity)
+            end
 
-        self:worker_delete(worker, false)
+            self:worker_delete(worker, false)
+        end
     end
 end
 

--- a/examples/PHP/mdbroker.php
+++ b/examples/PHP/mdbroker.php
@@ -104,13 +104,12 @@ class Mdbroker {
     }
     
     /**
-     * Delete any idle workers that haven't pinged us in a while. Workers
-     *are oldest to most recent, so we stop at the first alive worker.
+     * Delete any idle workers that haven't pinged us in a while.
      */
     public function purge_workers() {
         foreach($this->waiting as $id => $worker) {
             if(microtime(true) < $worker->expiry) {
-                break; //  Worker is alive, we're done here
+                continue; //  Worker is alive, we're done here
             }
             if($this->verbose) {
                 printf("I: deleting expired worker: %s %s",


### PR DESCRIPTION
The previous behaviour was not consistent with the Majordomo Protocol
specification (http://rfc.zeromq.org/spec:7).

Specification states:

«A peer MUST consider the other peer "disconnected" if no heartbeat
arrives within some multiple of that interval (usually 3-5). (...) If the broker
detects that the worked has disconnected, it SHOULD stop sending it
messages of any type.»

Conditions under which the problem occurs:

Admittedly, the "waiting" queue contains workers in order from oldest to
most recent, but the further queue elements might become unavailable
and expire before the first one does, for instance if the first worker keeps
sending heartbeats to broker and the further ones don't. Then the waiting
queue will contain an available worker at its beginning and expired workers
further on.

Previous behaviour:

The purging mechanism will never get to check the expired further workers
if the first one is available. The broker will continue sending heartbeat
messages to these expired workers.

Proposed behaviour:

Go through the entire waiting list.

Note: the proposed patch has been commited to all languages containing
the Majordomo example.
