### PR TITLE
Fixed taskvent python example

### DIFF
--- a/examples/Python/taskvent.py
+++ b/examples/Python/taskvent.py
@@ -14,12 +14,16 @@ context = zmq.Context()
 sender = context.socket(zmq.PUSH)
 sender.bind("tcp://*:5557")
 
+# Socket with direct access to the sink: used to syncronize start of batch
+sink = context.socket(zmq.PUSH)
+sink.connect("tcp://localhost:5558")
+
 print "Press Enter when the workers are ready: "
 _ = raw_input()
 print "Sending tasks to workers..."
 
 # The first message is "0" and signals start of batch
-sender.send('0')
+sink.send('0')
 
 # Initialize random number generator
 random.seed()


### PR DESCRIPTION
The taskvent example in python did not correctly syncronize the start
of the batch with the sink, corrected.
