### PR TITLE
Wrong variable called in ruby example wuclient

### DIFF
--- a/examples/Ruby/wuclient.rb
+++ b/examples/Ruby/wuclient.rb
@@ -17,7 +17,7 @@ subscriber = context.socket(ZMQ::SUB)
 subscriber.connect("tcp://localhost:5556")
 
 # Subscribe to zipcode, default is NYC, 10001
-filter = ARGV.size > 0 ? argv[0] : "10001 "
+filter = ARGV.size > 0 ? ARGV[0] : "10001 "
 subscriber.setsockopt(ZMQ::SUBSCRIBE, filter)
 
 # Process 100 updates


### PR DESCRIPTION
Hello,

It should be ARGV[0], argv is undefined in wuclient.rb:20.

Regards,

PS : I'm testing github online fork'n'edit feature, sorry if I end up messing something.
