### PR TITLE
Fixes to Ruby examples.

### DIFF
--- a/examples/Ruby/durapub.rb
+++ b/examples/Ruby/durapub.rb
@@ -14,7 +14,7 @@ publisher = context.socket(ZMQ::PUB)
 publisher.bind("tcp://127.0.0.1:5565")
 
 # Wait for synchronization request
-sync_request = sync.recv_string()
+sync.recv_string(sync_request = '')
 
 # Now broadcast exactly 10 updates with pause
 10.times do |update_number|

--- a/examples/Ruby/durapub2.rb
+++ b/examples/Ruby/durapub2.rb
@@ -22,7 +22,7 @@ publisher.setsockopt(ZMQ::SWAP, 25000000)
 publisher.bind("tcp://127.0.0.1:5565")
 
 # Wait for synchronization request
-sync_request = sync.recv_string()
+sync.recv_string(sync_request = '')
 
 # Now broadcast exactly 10 updates with pause
 10.times do |update_number|

--- a/examples/Ruby/durasub.rb
+++ b/examples/Ruby/durasub.rb
@@ -18,7 +18,7 @@ sync.send_string("")
 
 # Get updates, exit when told to do so
 loop do
-  message = subscriber.recv_string
+  subscriber.recv_string(message = '')
   puts message
   if message == "END"
     break

--- a/examples/Ruby/hwclient.rb
+++ b/examples/Ruby/hwclient.rb
@@ -12,6 +12,6 @@ requester.connect("tcp://localhost:5555")
   puts "Sending request #{request_nbr}..."
   requester.send_string "Hello"
 
-  reply = requester.recv_string
+  reply = requester.recv_string ''
   puts "Received reply #{request_nbr}: [#{reply}]"
 end

--- a/examples/Ruby/hwserver.rb
+++ b/examples/Ruby/hwserver.rb
@@ -2,7 +2,7 @@
 # this code is licenced under the MIT/X11 licence.
 
 require 'rubygems'
-require 'zmq'
+require 'ffi-rzmq'
 
 context = ZMQ::Context.new(1)
 
@@ -14,7 +14,7 @@ socket.bind("tcp://*:5555")
 
 while true do
   # Wait for next request from client
-  request = socket.recv
+  request = socket.recv_string ('')
 
   puts "Received request. Data: #{request.inspect}"
 
@@ -22,6 +22,6 @@ while true do
   sleep 1
 
   # Send reply back to client
-  socket.send("world")
+  socket.send_string("world")
 
 end

--- a/examples/Ruby/lpclient.rb
+++ b/examples/Ruby/lpclient.rb
@@ -3,13 +3,13 @@
 # Author: Han Holl <han.holl@pobox.com>
 
 require 'rubygems'
-require 'zmq'
+require 'ffi-rzmq'
 
 class LPClient
   def initialize(connect, retries = nil, timeout = nil)
     @connect = connect
     @retries = (retries || 3).to_i
-    @timeout = (timeout || 3).to_i
+    @timeout = (timeout || 10).to_i
     @ctx = ZMQ::Context.new(1)
     client_sock
     at_exit do

--- a/examples/Ruby/mspoller.rb
+++ b/examples/Ruby/mspoller.rb
@@ -27,11 +27,15 @@ while true
   poller.poll(:blocking)
   poller.readables.each do |socket|
     if socket === receiver
-      message = socket.recv_string
+      socket.recv_string(message = '')
       # process task
+       puts "task: #{message}"
+      
     elsif socket === subscriber
-      message = socket.recv_string
+      socket.recv_string(message = '')
       # process weather update
+      puts "weather: #{message}"
+      
     end
   end
 end

--- a/examples/Ruby/msreader.rb
+++ b/examples/Ruby/msreader.rb
@@ -19,12 +19,14 @@ subscriber.connect('tcp://localhost:5556')
 subscriber.setsockopt(ZMQ::SUBSCRIBE, '10001')
 
 while true
-  if receiver_msg = receiver.recv_string(ZMQ::NOBLOCK) && !receiver_msg.empty?
+  if receiver.recv_string(receiver_msg = '',ZMQ::NOBLOCK) && !receiver_msg.empty?
     # process task
+    puts "receiver: #{receiver_msg}"
   end
 
-  if subscriber_msg = subscriber.recv_string(ZMQ::NOBLOCK) && !subscriber_msg.empty?
+  if subscriber.recv_string(subscriber_msg = '',ZMQ::NOBLOCK) && !subscriber_msg.empty?
     # process weather update
+    puts "weather: #{subscriber_msg}"
   end
 
   # No activity, so sleep for 1 msec

--- a/examples/Ruby/mtrelay.rb
+++ b/examples/Ruby/mtrelay.rb
@@ -19,7 +19,7 @@ def step2(context)
   Thread.new{step1(context)}
 
   # Wait for signal and pass it on
-  receiver.recv_string
+  receiver.recv_string('')
 
   # Connect to step3 and tell it we're ready
   xmitter = context.socket(ZMQ::PAIR)
@@ -36,6 +36,6 @@ receiver.bind("inproc://step3")
 Thread.new{step2(context)}
 
 # Wait for signal
-receiver.recv_string
+receiver.recv_string('')
 
 puts "Test successful!"

--- a/examples/Ruby/mtserver.rb
+++ b/examples/Ruby/mtserver.rb
@@ -11,7 +11,7 @@ def worker_routine(context)
   receiver.connect("inproc://workers")
 
   loop do 
-    string = receiver.recv_string
+    receiver.recv_string(string = '')
     puts "Received request: [#{string}]"
     # Do some 'work'
     sleep(1)

--- a/examples/Ruby/rrbroker.rb
+++ b/examples/Ruby/rrbroker.rb
@@ -20,14 +20,14 @@ loop do
   poller.readables.each do |socket|
     if socket === frontend
       loop do
-        message = socket.recv_string
+        socket.recv_string(message = '')
         more = socket.more_parts?
         backend.send_string(message, more ? ZMQ::SNDMORE : 0)
         break unless more
       end
     elsif socket === backend
       loop do
-        message = socket.recv_string
+        socket.recv_string(message = '')
         more = socket.more_parts?
         frontend.send_string(message, more ? ZMQ::SNDMORE : 0)
         break unless more

--- a/examples/Ruby/rrclient.rb
+++ b/examples/Ruby/rrclient.rb
@@ -12,6 +12,6 @@ socket.connect('tcp://localhost:5559')
   string = "Hello #{request}"
   socket.send_string(string)
   puts "Sending string [#{string}]"
-  message = socket.recv_string
+  socket.recv_string(message = '')
   puts "Received reply #{request}[#{message}]"
 end

--- a/examples/Ruby/rrserver.rb
+++ b/examples/Ruby/rrserver.rb
@@ -9,7 +9,7 @@ socket = context.socket(ZMQ::REP)
 socket.connect('tcp://localhost:5560')
 
 loop do
-  message = socket.recv_string
+  socket.recv_string(message = '')
   puts "Received request: #{message}"
   socket.send_string('World')
 end

--- a/examples/Ruby/syncpub.rb
+++ b/examples/Ruby/syncpub.rb
@@ -23,7 +23,7 @@ puts "Waiting for subscribers"
 subscribers = 0 
 begin 
   # wait for synchronization request
-  syncservice.recv_string
+  syncservice.recv_string('')
   # send synchronization reply
   syncservice.send_string("")
   subscribers+=1

--- a/examples/Ruby/syncsub.rb
+++ b/examples/Ruby/syncsub.rb
@@ -23,12 +23,12 @@ synclient.connect("tcp://localhost:5562")
 synclient.send_string("")
 
 # - wait for synchronization reply
-synclient.recv_string
+synclient.recv_string('')
 
 # Third, get our updates and report how many we got
 update_nbr=0
 loop do 
-  string = subscriber.recv_string
+  subscriber.recv_string(string = '')
   break if string == "END"
   update_nbr+=1
 end

--- a/examples/Ruby/tasksink.rb
+++ b/examples/Ruby/tasksink.rb
@@ -13,12 +13,12 @@ receiver = context.socket(ZMQ::PULL)
 receiver.bind("tcp://*:5558")
 
 # Wait for start of batch
-receiver.recv_string
+receiver.recv_string('')
 tstart = Time.now
 
 # Process 100 confirmations
 100.times do |task_nbr|
-  receiver.recv_string
+  receiver.recv_string('')
   $stdout << ((task_nbr % 10 == 0) ? ':' : '.')
   $stdout.flush
 end

--- a/examples/Ruby/tasksink2.rb
+++ b/examples/Ruby/tasksink2.rb
@@ -16,12 +16,12 @@ controller = context.socket(ZMQ::PUB)
 controller.bind("tcp://*:5559")
 
 # Wait for start of batch
-receiver.recv_string
+receiver.recv_string('')
 tstart = Time.now
 
 # Process 100 confirmations
 100.times do |task_nbr|
-  receiver.recv_string
+  receiver.recv_string('')
   $stdout << ((task_nbr % 10 == 0) ? ':' : '.')
   $stdout.flush
 end

--- a/examples/Ruby/taskwork.rb
+++ b/examples/Ruby/taskwork.rb
@@ -21,8 +21,8 @@ sender.connect("tcp://localhost:5558")
 
 # Process tasks forever
 while true
-  msec = receiver.recv_string
-
+  
+  receiver.recv_string(msec = '')
   # Simple progress indicator for the viewer
   $stdout << "#{msec}."
   $stdout.flush

--- a/examples/Ruby/taskwork2.rb
+++ b/examples/Ruby/taskwork2.rb
@@ -31,7 +31,7 @@ while true
   items = poller.poll()
   poller.readables.each do |item| 
    if item === receiver
-    msec = receiver.recv_string
+    receiver.recv_string(msec ='')
  
     # Simple progress indicator for the viewer
     $stdout << "#{msec}."

--- a/examples/Ruby/wuclient.rb
+++ b/examples/Ruby/wuclient.rb
@@ -23,7 +23,10 @@ subscriber.setsockopt(ZMQ::SUBSCRIBE, filter)
 # Process 100 updates
 total_temp = 0
 1.upto(COUNT) do |update_nbr|
-  zipcode, temperature, relhumidity = subscriber.recv_string.split.map(&:to_i)
+  s = ''
+  subscriber.recv_string(s)#.split.map(&:to_i)
+  
+  zipcode, temperature, relhumidity = s.split.map(&:to_i)
   total_temp += temperature
 end
 

--- a/examples/Ruby/wuserver.rb
+++ b/examples/Ruby/wuserver.rb
@@ -19,5 +19,6 @@ while true
   relhumidity = rand(50) + 10
 
   update = "%05d %d %d" % [zipcode, temperature, relhumidity]
+  puts update
   publisher.send_string(update)
 end


### PR DESCRIPTION
I've made a number of fixes to the ruby demo code.  One thing I was wondering is if I should take a pass through and have them all use the ffi-rzmq library, instead of the mix of that gem and "zmq".  

Also, it's quite clear the demos have been coded by more then one person as the style differs between some of the basic demos and the more advanced ones.  Do you wish them to be made all the same?  Maybe that is a sperate pull request!
