### PR TITLE
Removed redundant while loop in wuproxy.py to improve clarity.

### DIFF
--- a/examples/Python/wuproxy.py
+++ b/examples/Python/wuproxy.py
@@ -19,13 +19,10 @@ frontend.setsockopt(zmq.SUBSCRIBE, '')
 
 # Shunt messages out to our own subscribers
 while True:
-    while True:
-
-        # Process all parts of the message
-        message = frontend.recv()
-        more = frontend.getsockopt(zmq.RCVMORE)
-        if more:
-            backend.send(message, zmq.SNDMORE)
-        else:
-            backend.send(message)
-            break # Last message part
+    # Process all parts of the message
+    message = frontend.recv()
+    more = frontend.getsockopt(zmq.RCVMORE)
+    if more:
+        backend.send(message, zmq.SNDMORE)
+    else:
+        backend.send(message)  # last message part


### PR DESCRIPTION
The outer while loop is unnecessary in the wuproxy example (no work done in the outer loop, and the break is the last instruction in the inner loop). It confused me when reading the code, so I've removed it from the Python example. Let me know if I'm missing something subtle (or really, really obvious : ) ).
