### PR TITLE
Translate 0MQ to use the fancy Ø in example titles

### DIFF
--- a/bin/z2w
+++ b/bin/z2w
@@ -162,7 +162,7 @@ while (<>) {
     }
     #  Process named codeblock
     elsif (/\[\[code\s+type=\"example\"\s+title=\"([^"]+)\"\s+name=\"([^"]+)\"(\s+language=\"([^"]+)\")?\]\]/) {
-        $title = $1;
+        $title = zmq_symbol ($1); #  Some titles have '0MQ'
         $name = $2;
         $language = $4;
         if ($language) {
@@ -224,8 +224,7 @@ while (<>) {
             chop;
             last if /\[\[\/code\]\]/;
             s/#/$figure/;
-            s/0MQ/ØMQ/g;
-            s/0\\MQ/0MQ/g;
+            $_ = zmq_symbol ($_);
             print IMAGE "$_\n";
         }
         print IMAGE "</pre>\n";
@@ -414,8 +413,7 @@ sub expand_symbols {
 
     return unless ($_);                 #   Quit if input string is empty
 
-    s/0MQ/ØMQ/g;
-    s/0\\MQ/0MQ/g;
+    $_ = zmq_symbol ($_);
 
     for (;;) {
         #   Force expansion from end of string first, so things like
@@ -464,6 +462,19 @@ sub expand_symbols {
             last;
         }
     }
+    return $_;
+}
+
+
+#   Translate 0MQ into ØMQ and 0\MQ into 0MQ
+sub zmq_symbol {
+    local ($_) = @_;
+
+    return unless ($_);                 #   Quit if input string is empty
+
+    s/0MQ/ØMQ/g;
+    s/0\\MQ/0MQ/g;
+
     return $_;
 }
 


### PR DESCRIPTION
The title on this page[1] looked weird so I changed z2w to do the 0MQ -> ØMQ translation for example titles too. (Pulled it into a sub since it would have been duplicated thrice)

[1]http://zguide.zeromq.org/py:version
