### PR TITLE
Change bb2wd so it preserves spaces inside of [b]s

### DIFF
--- a/bin/bb2wd
+++ b/bin/bb2wd
@@ -33,7 +33,7 @@ s/\[i\]/[[span style="font-style:italic"]]/mg;
 s/\[\/i\]/[[\/span]]/mg;
 
 s/\[b\]/**/mg;
-s/\s*\[\/b\]/**/mg;
+s/(\s*)\[\/b\]/**$1/mg;
 
 #   Escape [ and ]
 s/\[(\[*)/\@\@[$1\@\@/mg;


### PR DESCRIPTION
Pygmentize outputs [b]foo [/b]bar instead of [b]foo[/b] bar, but bb2wd strips the space.

closes #70
