### PR TITLE
Fix Python MajorDomo broker to reject workers claiming mmi.* service names

### DIFF
--- a/examples/Python/mdbroker.py
+++ b/examples/Python/mdbroker.py
@@ -146,12 +146,13 @@ class MajorDomoBroker(object):
         worker = self.require_worker(sender)
 
         if (MDP.W_READY == command):
+            assert len(msg) >= 1 # At least, a service name
+            service = msg.pop(0)
             # Not first command in session or Reserved service name
-            if (worker_ready or sender.startswith(self.INTERNAL_SERVICE_PREFIX)):
+            if (worker_ready or service.startswith(self.INTERNAL_SERVICE_PREFIX)):
                 self.delete_worker(worker, True)
             else:
                 # Attach worker to service and mark as idle
-                service = msg.pop(0)
                 worker.service = self.require_service(service)
                 self.worker_waiting(worker)
             


### PR DESCRIPTION
This is a simple fix to the MajorDomo broker example. It used to test sender address for the "mmi." prefix rather than the advertised service name. @minrk, does this look good to you?
