### PR TITLE
fixed Clojure example: wuclient

### DIFF
--- a/examples/Clojure/wuclient.clj
+++ b/examples/Clojure/wuclient.clj
@@ -11,13 +11,15 @@
 ;; Isaiah Peng <issaria@gmail.com>
 ;;
 
+(def total-temp (atom 0))
+
 (defn -main [& args]
   (let [subscriber (-> 1 mq/context (mq/socket mq/sub))
         filter (or (first args) "10001 ")
         args-temp (atom 0)
         nbr 100]
-    (println "Collecting updates from weather server...")
-    (mq/connect subscriber "ipc://weather")
+    (println "Collecting updates from weather server for " filter)
+    (mq/connect subscriber "tcp://localhost:5556")
     (mq/subscribe subscriber filter)
     (dotimes [i nbr]
       (let [string (mq/recv-str subscriber)


### PR DESCRIPTION
The Clojure wuclient example was missing a variable and the connection params were wrong, so in addition to a syntax error, it just wouldn't work.  :-)  I fixed them and will ping you if I run across any more, this is a very awesome project.
