### PR TITLE
zhelpers.py ROUTER/DEALER -> XREP/XREQ

### DIFF
--- a/examples/Python/zhelpers.py
+++ b/examples/Python/zhelpers.py
@@ -11,9 +11,9 @@ import zmq
 
 # fix ROUTER/DEALER aliases, missing from pyzmq < 2.1.9
 if not hasattr(zmq, 'ROUTER'):
-    zmq.ROUTER = zmq.ROUTER
+    zmq.ROUTER = zmq.XREP
 if not hasattr(zmq, 'DEALER'):
-    zmq.DEALER = zmq.DEALER
+    zmq.DEALER = zmq.XREQ
 
 
 # Receives all message parts from socket, prints neatly


### PR DESCRIPTION
803902e was overzealous in replacing ROUTER and DEALER with XREP and XREQ respectively.
