### PR TITLE
C++ example of mdbroker is broken

### DIFF
--- a/examples/C++/mdbroker.cpp
+++ b/examples/C++/mdbroker.cpp
@@ -137,7 +137,7 @@ public:
        worker * wrk = m_waiting.size()>0 ? m_waiting.front() : 0;
        while (wrk) {
            if (!wrk->expired ()) {
-               continue;              //  Worker is alive, we're done here
+               break;              //  Worker is alive, we're done here
            }
            if (m_verbose) {
                s_console ("I: deleting expired worker: %s",
@@ -188,6 +188,12 @@ public:
            zmsg *msg = srv->m_requests.size() ? srv->m_requests.front() : 0;
            srv->m_requests.erase(srv->m_requests.begin());
            worker_send (wrk, (char*)MDPW_REQUEST, "", msg);
+       	   for(std::vector<worker*>::iterator it = m_waiting.begin(); it != m_waiting.end(); it++) {
+              if (*it == wrk) {
+                 it = m_waiting.erase(it)-1;
+              }
+           }
+
            delete msg;
        }
    }


### PR DESCRIPTION
detection of expired working was not exiting upon first alive worker and thus was hanging

when dispatching requests to workers the worker was not removed from the m_waiting list. so for each client request an additional entry in the list is made and the m_waiting list grows with each client request
