### PR TITLE
Made the divide and conquer C++ example work.

### DIFF
--- a/examples/C++/tasksink.cpp
+++ b/examples/C++/tasksink.cpp
@@ -32,9 +32,9 @@ int main (int argc, char *argv[])
 
         receiver.recv(&message);
         if ((task_nbr / 10) * 10 == task_nbr)
-            std::cout << ":";
+            std::cout << ":" << std::flush;
         else
-            std::cout << ".";
+            std::cout << "." << std::flush;
     }
     //  Calculate and report duration of batch
     struct timeval tend, tdiff;

--- a/examples/C++/taskvent.cpp
+++ b/examples/C++/taskvent.cpp
@@ -26,9 +26,11 @@ int main (int argc, char *argv[])
     std::cout << "Sending tasks to workers...\n" << std::endl;
 
     //  The first message is "0" and signals start of batch
+    zmq::socket_t sink(context, ZMQ_PUSH);
+    sink.connect("tcp://localhost:5558");
     zmq::message_t message(2);
     memcpy(message.data(), "0", 1);
-    sender.send(message);
+    sink.send(message);
 
     //  Initialize random number generator
     srandom ((unsigned) time (NULL));


### PR DESCRIPTION
The C version pushes the begin message to the tasksink, but the c++ one does not. Also, I added flushing of stdout in the tasksink so that the chars don't all just show up all at once.
