### PR TITLE
Fix bug in clonesrv6

### DIFF
--- a/examples/C/clonesrv6.c
+++ b/examples/C/clonesrv6.c
@@ -152,6 +152,7 @@ s_snapshots (zloop_t *loop, zmq_pollitem_t *poller, void *args)
             kvmsg_destroy (&kvmsg);
             free (subtree);
         }
+        zframe_destroy(&identity);
     }
     return 0;
 }
@@ -345,7 +346,8 @@ s_subscriber (zloop_t *loop, zmq_pollitem_t *poller, void *args)
         zsocket_connect (snapshot, "tcp://localhost:%d", self->peer);
         zclock_log ("I: asking for snapshot from: tcp://localhost:%d",
                     self->peer);
-        zstr_send (snapshot, "ICANHAZ?");
+        zstr_sendm (snapshot, "ICANHAZ?");
+        zstr_send (snapshot, ""); // blank subtree to get all
         while (TRUE) {
             kvmsg_t *kvmsg = kvmsg_recv (snapshot);
             if (!kvmsg)


### PR DESCRIPTION
This should solve issue #173. The master always expects a "snapshots" request to include a frame of "ICANHAZ?" _and_ a frame indicating the subtree. The slave was not sending a subtree frame, so the master gets very confused when clients try to connect. I think the right fix is for the slave to send an empty subtree ("") frame.
