### PR TITLE
Name appears in CONTRIBUTORS twice... removing one copy

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -81,7 +81,7 @@ Stephen McQuay <stephen@mcquay.me> (C++)
 Rob Gagnon <rgagnon24@gmail.com> (PHP)
 Erik Allik <eallik@gmail.com> (Python)
 Arnaud Cogoluègnes (Java)
-Rob Gagnon (PHP)
+
 Errata and Suggestions
 ----------------------
 


### PR DESCRIPTION
:-) I had already added my name to the file during commit of flclient1.php/flserver1.php, so second addition is not needed
