### PR TITLE
Rename variable "filter" to "zip_filter" to avoid conflict and confusion...

### DIFF
--- a/examples/Python/wuclient.py
+++ b/examples/Python/wuclient.py
@@ -15,8 +15,8 @@ print "Collecting updates from weather server..."
 socket.connect ("tcp://localhost:5556")
 
 # Subscribe to zipcode, default is NYC, 10001
-filter = sys.argv[1] if len(sys.argv) > 1 else "10001"
-socket.setsockopt(zmq.SUBSCRIBE, filter)
+zip_filter = sys.argv[1] if len(sys.argv) > 1 else "10001"
+socket.setsockopt(zmq.SUBSCRIBE, zip_filter)
 
 # Process 5 updates
 total_temp = 0
@@ -26,4 +26,4 @@ for update_nbr in range (5):
     total_temp += int(temperature)
 
 print "Average temperature for zipcode '%s' was %dF" % (           
-      filter, total_temp / update_nbr)
+      zip_filter, total_temp / update_nbr)


### PR DESCRIPTION
... with Python builtin function filter()

Because, after all, extra confusion is not a feature. :)
