### PR TITLE
hwserver.rb/hwclient.rb bugfix to reflect the new ffi-rzmq API changes

### DIFF
--- a/examples/Ruby/hwclient.rb
+++ b/examples/Ruby/hwclient.rb
@@ -12,6 +12,8 @@ requester.connect("tcp://localhost:5555")
   puts "Sending request #{request_nbr}..."
   requester.send_string "Hello"
 
-  reply = requester.recv_string ''
+  reply = ''
+  rc = requester.recv_string(reply)
+  
   puts "Received reply #{request_nbr}: [#{reply}]"
 end

--- a/examples/Ruby/hwserver.rb
+++ b/examples/Ruby/hwserver.rb
@@ -14,7 +14,8 @@ socket.bind("tcp://*:5555")
 
 while true do
   # Wait for next request from client
-  request = socket.recv_string ('')
+  request = ''
+  rc = socket.recv_string(request)
 
   puts "Received request. Data: #{request.inspect}"
 


### PR DESCRIPTION
Hi imatix,

I've fixed hwserver.rb and hwclient.rb to reflect the new ffi-rzmq API changes.
The output of the server and client are now:

``` bash
$ ruby hwserver.rb 
Starting Hello World server...
Received request. Data: "Hello"
Received request. Data: "Hello"
Received request. Data: "Hello"
Received request. Data: "Hello"
Received request. Data: "Hello"
Received request. Data: "Hello"
Received request. Data: "Hello"
Received request. Data: "Hello"
Received request. Data: "Hello"
Received request. Data: "Hello"

$ ruby hwclient.rb 
Connecting to hello world server...
Sending request 0...
Received reply 0: [world]
Sending request 1...
Received reply 1: [world]
Sending request 2...
Received reply 2: [world]
Sending request 3...
Received reply 3: [world]
Sending request 4...
Received reply 4: [world]
Sending request 5...
Received reply 5: [world]
Sending request 6...
Received reply 6: [world]
Sending request 7...
Received reply 7: [world]
Sending request 8...
Received reply 8: [world]
Sending request 9...
Received reply 9: [world]
```

Regards,
Tom van Leeuwen

(BTW: This is my first pull request ever!)
