### PR TITLE
Fixed worker expiration conversion into seconds

### DIFF
--- a/examples/PHP/mdbroker.php
+++ b/examples/PHP/mdbroker.php
@@ -269,7 +269,7 @@ class Mdbroker {
             }
         } else if($command == MDPW_HEARTBEAT) {
             if($worker_ready) {
-                $worker->expiry = microtime(true) + HEARTBEAT_EXPIRY;
+                $worker->expiry = microtime(true) + (HEARTBEAT_EXPIRY/1000);
             } else {
                 $this->worker_delete($worker, true);
             }


### PR DESCRIPTION
Issue results in workers being set with extremely long expiration times
and thus not expiring properly.
