### PR TITLE
Use "hex" for 32-char UUID string, not str()

### DIFF
--- a/examples/Python/titanic.py
+++ b/examples/Python/titanic.py
@@ -52,7 +52,7 @@ def titanic_request (pipe):
             os.mkdir(TITANIC_DIR)
 
         # Generate UUID and save message to disk
-        uuid = str(uuid4())
+        uuid = uuid4().hex
         filename = request_filename (uuid)
         with open(filename, 'w') as f:
             pickle.dump(request, f)


### PR DESCRIPTION
The str() code here produces a UUID string with inlined dashes, like this: "e771a956-4974-474f-a1e9-0b48e1bb9d4e". It'd be better to use the "hex" attribute, which produces a Titanic-spec-compliant 32-char string like this: "e771a9564974474fa1e90b48e1bb9d4e".
