### PR TITLE
Fixed some compilation errors/warnings in C examples

### DIFF
--- a/examples/C/build
+++ b/examples/C/build
@@ -10,7 +10,7 @@ if [ /$1/ = /all/ ]; then
     echo "Building C examples..."
     for MAIN in `egrep -l "main \(" *.c`; do
         echo "$MAIN"
-        ./c -l -lzmq -lczmq -q $MAIN
+        ./c -l -lzmq -lczmq -luuid -q $MAIN
     done
 elif [ /$1/ = /clean/ ]; then
     echo "Cleaning C examples directory..."
@@ -20,7 +20,7 @@ elif [ /$1/ = /clean/ ]; then
     done
 elif [ -f $1.c ]; then
     echo "$1"
-    ./c -l -lzmq -lczmq -q $1
+    ./c -l -lzmq -lczmq -luuid -q $1
 else
     echo "syntax: build all | clean"
 fi

--- a/examples/C/clonesrv2.c
+++ b/examples/C/clonesrv2.c
@@ -5,7 +5,7 @@
 //  Lets us build this source without creating a library
 #include "kvsimple.c"
 
-static int s_send_single (char *key, void *data, void *args);
+static int s_send_single (const char *key, void *data, void *args);
 static void state_manager (void *args, zctx_t *ctx, void *pipe);
 
 int main (void)
@@ -45,7 +45,7 @@ typedef struct {
 //  Send one state snapshot key-value pair to a socket
 //  Hash item data is our kvmsg object, ready to send
 static int
-s_send_single (char *key, void *data, void *args)
+s_send_single (const char *key, void *data, void *args)
 {
     kvroute_t *kvroute = (kvroute_t *) args;
     //  Send identity of recipient first

--- a/examples/C/clonesrv3.c
+++ b/examples/C/clonesrv3.c
@@ -14,7 +14,7 @@ typedef struct {
 //  Send one state snapshot key-value pair to a socket
 //  Hash item data is our kvmsg object, ready to send
 static int
-s_send_single (char *key, void *data, void *args)
+s_send_single (const char *key, void *data, void *args)
 {
     kvroute_t *kvroute = (kvroute_t *) args;
     //  Send identity of recipient first

--- a/examples/C/clonesrv4.c
+++ b/examples/C/clonesrv4.c
@@ -15,7 +15,7 @@ typedef struct {
 //  Send one state snapshot key-value pair to a socket
 //  Hash item data is our kvmsg object, ready to send
 static int
-s_send_single (char *key, void *data, void *args)
+s_send_single (const char *key, void *data, void *args)
 {
     kvroute_t *kvroute = (kvroute_t *) args;
     kvmsg_t *kvmsg = (kvmsg_t *) data;

--- a/examples/C/clonesrv5.c
+++ b/examples/C/clonesrv5.c
@@ -71,7 +71,7 @@ typedef struct {
 
 //  We call this function for each key-value pair in our hash table
 static int
-s_send_single (char *key, void *data, void *args)
+s_send_single (const char *key, void *data, void *args)
 {
     kvroute_t *kvroute = (kvroute_t *) args;
     kvmsg_t *kvmsg = (kvmsg_t *) data;
@@ -157,7 +157,7 @@ s_collector (zloop_t *loop, zmq_pollitem_t *poller, void *args)
 //  If key-value pair has expired, delete it and publish the
 //  fact to listening clients.
 static int
-s_flush_single (char *key, void *data, void *args)
+s_flush_single (const char *key, void *data, void *args)
 {
     clonesrv_t *self = (clonesrv_t *) args;
 

--- a/examples/C/clonesrv6.c
+++ b/examples/C/clonesrv6.c
@@ -98,7 +98,7 @@ int main (int argc, char *argv [])
     //  event handlers, and then start the bstar reactor. This finishes
     //  when the user presses Ctrl-C, or the process receives a SIGINT
     //  interrupt:
-    
+
     //  Register state change handlers
     bstar_new_master (self->bstar, s_new_master, self);
     bstar_new_slave (self->bstar, s_new_slave, self);
@@ -139,7 +139,7 @@ typedef struct {
 //  Send one state snapshot key-value pair to a socket
 //  Hash item data is our kvmsg object, ready to send
 static int
-s_send_single (char *key, void *data, void *args)
+s_send_single (const char *key, void *data, void *args)
 {
     kvroute_t *kvroute = (kvroute_t *) args;
     kvmsg_t *kvmsg = (kvmsg_t *) data;
@@ -249,7 +249,7 @@ s_collector (zloop_t *loop, zmq_pollitem_t *poller, void *args)
 //  If key-value pair has expired, delete it and publish the
 //  fact to listening clients.
 static int
-s_flush_single (char *key, void *data, void *args)
+s_flush_single (const char *key, void *data, void *args)
 {
     clonesrv_t *self = (clonesrv_t *) args;
 
@@ -307,7 +307,7 @@ s_new_master (zloop_t *loop, zmq_pollitem_t *unused, void *args)
 
     self->master = TRUE;
     self->slave = FALSE;
-    
+
     //  Stop subscribing to updates
     zmq_pollitem_t poller = { self->subscriber, 0, ZMQ_POLLIN };
     zloop_poller_end (bstar_zloop (self->bstar), &poller);
@@ -331,7 +331,7 @@ s_new_slave (zloop_t *loop, zmq_pollitem_t *unused, void *args)
     zhash_destroy (&self->kvmap);
     self->master = FALSE;
     self->slave = TRUE;
-    
+
     //  Start subscribing to updates
     zmq_pollitem_t poller = { self->subscriber, 0, ZMQ_POLLIN };
     zloop_poller (bstar_zloop (self->bstar), &poller, s_subscriber, self);

--- a/examples/C/flcliapi.c
+++ b/examples/C/flcliapi.c
@@ -143,7 +143,7 @@ server_destroy (server_t **self_p)
 }
 
 int
-server_ping (char *key, void *server, void *socket)
+server_ping (const char *key, void *server, void *socket)
 {
     server_t *self = (server_t *) server;
     if (zclock_time () >= self->ping_at) {
@@ -157,7 +157,7 @@ server_ping (char *key, void *server, void *socket)
 }
 
 int
-server_tickless (char *key, void *server, void *arg)
+server_tickless (const char *key, void *server, void *arg)
 {
     server_t *self = (server_t *) server;
     uint64_t *tickless = (uint64_t *) arg;

--- a/examples/C/lruqueue.c
+++ b/examples/C/lruqueue.c
@@ -122,7 +122,7 @@ int main (void)
             { frontend, 0, ZMQ_POLLIN, 0 }
         };
         //  Poll frontend only if we have available workers
-        int rc = zmq_poll (items, zlist_size (workers)? 2: 1, -1);
+        int rc = zmq_poll (items, available_workers ? 2 : 1, -1);
         if (rc == -1)
             break;              //  Interrupted
 


### PR DESCRIPTION
- `zhash_foreach` handler accepts `const char *`, but all prototypes were `char *`
- `lruqueue.c` was using `workers` variable which doesn't exist.
- A couple of files used uuid generation, for which `-luuid` is required.
