### PR TITLE
Fixed compilation issues in C++ examples

### DIFF
--- a/examples/C++/c
+++ b/examples/C++/c
@@ -177,6 +177,7 @@ if [ "$CCNAME" = "gcc" ]; then
     #
     elif [ "$UTYPE" = "Darwin" ]; then
         #  Use -start-group / -end-group for linking
+        STDLIBS="$STDLIBS -lstdc++"
         LINKTYPE="after"
     #
     #  Solaris-specific subsection
@@ -432,8 +433,11 @@ for i in $*; do
         fi
 
         TRACE="Compiling $FILENAME"
-        COMMAND="$CCPLUS -c $CCOPTS -I$INCDIR -o $FILENAME.$OBJEXT $FILENAME.cpp"
-
+        if [ "$USECPP" = "no" ]; then
+            COMMAND="$CCNAME -c $CCOPTS -I$INCDIR $FILENAME.c"
+        else
+            COMMAND="$CCPLUS -c $CCOPTS -I$INCDIR -o $FILENAME.opp $FILENAME.cpp"
+        fi
         if [ "$QUIET" = "no" ]; then
             if [ "$VERBOSE" = "no" ]; then
                 echo "$TRACE..."
@@ -466,8 +470,11 @@ for i in $*; do
     #   If okay, link if required
     if [ "$LINKUP" = "yes" ]; then
         TRACE="Linking $FILENAME"
-        COMMAND="$CCNAME $FILENAME.$OBJEXT $CCOPTS -o $FILENAME"
-
+        if [ "$USECPP" = "no" ]; then
+            COMMAND="$CCNAME $CCOPTS $FILENAME.o -o $FILENAME"
+        else
+            COMMAND="$CCPLUS $CCOPTS $FILENAME.opp -o $FILENAME"
+        fi
         case "$LINKTYPE" in
             gnu)
                 COMMAND="$COMMAND -Wl,--start-group $LIBLIST -Wl,--end-group -L. -L$LOCALLIBDIR -L$LIBDIR $STDLIBS"

--- a/examples/C++/durapub.cpp
+++ b/examples/C++/durapub.cpp
@@ -22,9 +22,8 @@ int main () {
     //  Now broadcast exactly 10 updates with pause
     int update_nbr;
     for (update_nbr = 0; update_nbr < 10; update_nbr++) {
-       
         std::ostringstream oss;
-        oss << "Update "<< update_nbr ;
+        oss << "Update " << update_nbr;
         s_send (publisher, oss.str());
         sleep (1);
     }

--- a/examples/C++/durapub2.cpp
+++ b/examples/C++/durapub2.cpp
@@ -19,11 +19,11 @@ int main () {
 
     //  Prevent publisher overflow from slow subscribers
     uint64_t hwm = 1;
-    publisher.setsockopt( ZMQ_HWM, &hwm, sizeof (hwm));
+    publisher.setsockopt(ZMQ_HWM, &hwm, sizeof (hwm));
 
     //  Specify swap space in bytes, this covers all subscribers
     uint64_t swap = 25000000;
-    publisher.setsockopt( ZMQ_SWAP, &swap, sizeof (swap));
+    publisher.setsockopt(ZMQ_SWAP, &swap, sizeof (swap));
     publisher.bind("tcp://*:5565");
 
     //  Wait for synchronization request
@@ -32,9 +32,8 @@ int main () {
     //  Now broadcast exactly 10 updates with pause
     int update_nbr;
     for (update_nbr = 0; update_nbr < 10; update_nbr++) {
-       
         std::ostringstream oss;
-        oss << "Update "<< update_nbr ;
+        oss << "Update " << update_nbr;
         s_send (publisher, oss.str());
         sleep (1);
     }

--- a/examples/C++/taskvent.cpp
+++ b/examples/C++/taskvent.cpp
@@ -8,7 +8,7 @@
 #include <zmq.hpp>
 #include <stdlib.h>
 #include <stdio.h>
-#include <time.h>
+#include <unistd.h>
 #include <iostream>
 
 #define within(num) (int) ((float) num * random () / (RAND_MAX + 1.0))
@@ -21,7 +21,7 @@ int main (int argc, char *argv[])
     zmq::socket_t  sender(context, ZMQ_PUSH);
     sender.bind("tcp://*:5557");
 
-    std::cout << "Press Enter when the workers are ready: " <<std::endl;
+    std::cout << "Press Enter when the workers are ready: " << std::endl;
     getchar ();
     std::cout << "Sending tasks to workers...\n" << std::endl;
 
@@ -39,7 +39,6 @@ int main (int argc, char *argv[])
     int task_nbr;
     int total_msec = 0;     //  Total expected cost in msecs
     for (task_nbr = 0; task_nbr < 100; task_nbr++) {
-
         int workload;
         //  Random workload from 1 to 100msecs
         workload = within (100) + 1;
@@ -49,7 +48,7 @@ int main (int argc, char *argv[])
         sprintf ((char *) message.data(), "%d", workload);
         sender.send(message);
     }
-    std::cout << "Total expected cost: " << total_msec <<" msec"<<std::endl;;
+    std::cout << "Total expected cost: " << total_msec << " msec" << std::endl;
     sleep (1);              //  Give 0MQ time to deliver
 
     return 0;

--- a/examples/C++/zhelpers.hpp
+++ b/examples/C++/zhelpers.hpp
@@ -34,6 +34,7 @@
 #include <sstream>
 
 #include <sys/time.h>
+#include <unistd.h>
 #include <time.h>
 #include <assert.h>
 #include <pthread.h>


### PR DESCRIPTION
- `sleep(unsigned)` function is defined in `unistd.h`, so include this file
  in zhelpers.hpp and sources that do not include `zhelpers.hpp`
- use `c` script from C examples, as it properly handles C++ linking

Also note that using `sleep` from `unistd.h` is not portable. The `s_sleep` function from `zhelpers.hpp` should be used instead. The build scripts `build` and `c` run on *nix only, so I guess portability to windows is not a main concern at the moment :)
