### PR TITLE
Added support for pkg-build in C/C++ build files

### DIFF
--- a/examples/C++/build
+++ b/examples/C++/build
@@ -6,11 +6,15 @@
 #   Note: may fail with g++/4.0.x, then
 #   build examples using 'g++ -o filename -lzmq filename.cpp'
 #
+ZMQOPTS='-lzmq'
+if pkg-config libzmq --exists; then
+  ZMQOPTS=$(pkg-config libzmq --cflags --libs)
+fi
 if [ /$1/ = /all/ ]; then
     echo "Building C++ examples..."
     for MAIN in `egrep -l "main \(" *.cpp`; do
         echo "$MAIN"
-        ./c -p -l -lzmq -q $MAIN
+        ./c -p -l $ZMQOPTS -q $MAIN
     done
 elif [ /$1/ = /clean/ ]; then
     echo "Cleaning C++ examples directory..."
@@ -20,7 +24,7 @@ elif [ /$1/ = /clean/ ]; then
     done
 elif [ -f $1.cpp ]; then
     echo "$1"
-    ./c -p -l -lzmq -q $1
+    ./c -p -l $ZMQOPTS -q $1
 else
     echo "syntax: build all | clean"
 fi

--- a/examples/C/build
+++ b/examples/C/build
@@ -6,11 +6,15 @@
 #   This controls whether we get debug or release builds
 test -z "$BOOM_MODEL" && BOOM_MODEL=debug
 
+ZMQOPTS='-lzmq -lczmq'
+if pkg-config libzmq libczmq --exists; then
+  ZMQOPTS=$(pkg-config libzmq libczmq --cflags --libs)
+fi
 if [ /$1/ = /all/ ]; then
     echo "Building C examples..."
     for MAIN in `egrep -l "main \(" *.c`; do
         echo "$MAIN"
-        ./c -l -lzmq -lczmq -luuid -q $MAIN
+        ./c -l $ZMQOPTS -luuid -q $MAIN
     done
 elif [ /$1/ = /clean/ ]; then
     echo "Cleaning C examples directory..."
@@ -20,7 +24,7 @@ elif [ /$1/ = /clean/ ]; then
     done
 elif [ -f $1.c ]; then
     echo "$1"
-    ./c -l -lzmq -lczmq -luuid -q $1
+    ./c -l $ZMQOPTS -luuid -q $1
 else
     echo "syntax: build all | clean"
 fi


### PR DESCRIPTION
If you have libzmq installed in a non-standard location you should modify the C/C++ build scripts so they can pass the appropriate paths to the compiler.

However, with this patch you can set `PKG_CONFIG_PATH` to point to the `*.pc` files installed from libzmq and the build scripts will use them instead.
