### PR TITLE
Little bug correction in examples

### DIFF
--- a/examples/Python/rrserver.py
+++ b/examples/Python/rrserver.py
@@ -7,7 +7,7 @@ import zmq
 
 context = zmq.Context()
 socket = context.socket(zmq.REP)
-socket.bind("tcp://localhost:5560")
+socket.connect("tcp://localhost:5560")
 
 while True:
     message = socket.recv()


### PR DESCRIPTION
Hi! I've made a small correction... I've substituted, in the python example rrserver.py, bind() with connect() because the rrbroker.py already bind the same port. They now work correctly.
