### PR TITLE
New examples in q using qzmq.

### DIFF
--- a/examples/Q/README
+++ b/examples/Q/README
@@ -1,0 +1,12 @@
+Examples in Q. Uses qzmq or https://github.com/jaeheum/qzmq.
+qzmq follows czmq rather than libzmq and examples here are translations from libzmq to czmq/qzmq.
+
+q version.q -q
+q identity.q -q
+
+q hwserver.q -q / in one terminal
+q hwclient.q -q / in another terminal
+q mtserver.q -q / is a multithreaded hwserver.q
+
+See LICENSE in examples directory.
+

--- a/examples/Q/hwclient.q
+++ b/examples/Q/hwclient.q
@@ -1,0 +1,15 @@
+//  Hello World client
+//  Connects REQ socket to tcp://localhost:5555
+//  Sends "Hello" to server, expects "World" back
+\l qzmq.q
+zclock.log "Connecting to hello world server..."
+ctx:zctx.new[]
+//  Socket to talk to server
+requester:zsocket.new[ctx; zmq`REQ]
+zsocket.connect[requester; `tcp://127.0.0.1:5555]
+do[10; m:zmsg.new[]; zmsg.push[m; f:zframe.new["Hello"]];
+  zmsg.send[m; requester]; zmsg.dump[zmsg.recv[requester]]]
+zsocket.destroy[ctx; requester]
+zctx.destroy[ctx]
+\\
+

--- a/examples/Q/hwserver.q
+++ b/examples/Q/hwserver.q
@@ -1,0 +1,21 @@
+//  Hello World server
+//  Binds REP socket to tcp://*:5555
+//  Expects "Hello" from client, replies with "World"
+\l qzmq.q
+ctx:zctx.new[]
+//  Socket to talk to clients
+responder:zsocket.new[ctx; zmq`REP]
+port:zsocket.bind[responder; `$"tcp://*:5555"]
+while[1b and not zctx.interrupted[];
+  //  Wait for next request from client
+  s:zmsg.recv responder;
+  //  Do some 'work'
+  zclock.sleep 1;
+  //  Send reply back to client
+  m1:zmsg.new[];
+  zmsg.push[m1; zframe.new["World"]];
+  zmsg.send[m1; responder]]
+//  We never get here but if we did, this would how we end
+zsocket.destroy[ctx; responder]
+zctx.destroy[ctx]
+

--- a/examples/Q/identity.q
+++ b/examples/Q/identity.q
@@ -1,0 +1,26 @@
+//  Demonstrate identities as used by the request-reply pattern.
+\l qzmq.q
+ctx:zctx.new[]
+sink:zsocket.new[ctx; zmq`ROUTER]
+port:zsocket.bind[sink; `inproc://example]
+//  First allow 0MQ to set the identity
+anonymous:zsocket.new[ctx; zmq`REQ]
+zsocket.connect[anonymous; `inproc://example]
+m0:zmsg.new[]
+zmsg.push[m0; zframe.new["ROUTER uses a generated UUID"]]
+zmsg.send[m0; anonymous]
+zmsg.dump[zmsg.recv[sink]]
+//  Then set the identity ourself
+identified:zsocket.new[ctx; zmq`REQ]
+zsockopt.set_identity[identified; "Hello"]
+zsocket.connect[identified; `inproc://example]
+m1:zmsg.new[]
+zmsg.push[m1; zframe.new["ROUTER socket users REQ's socket identity"]]
+zmsg.send[m1; identified]
+zmsg.dump[zmsg.recv[sink]]
+zsocket.destroy[ctx; sink]
+zsocket.destroy[ctx; anonymous]
+zsocket.destroy[ctx; identified]
+zctx.destroy[ctx]
+\\
+

--- a/examples/Q/mtserver.q
+++ b/examples/Q/mtserver.q
@@ -1,0 +1,37 @@
+//  Multithreaded Hello World server
+\l qzmq.q
+
+worker_routine:{[args; ctx; pipe]
+    //  Socket to talk to dispatcher
+    receiver:zsocket.new[ctx; zmq.REP];
+    zsocket.connect[receiver; `inproc://workers];
+    while[1b;
+        s:zstr.recv[receiver];
+        //  Do some 'work'
+        zclock.sleep 1;
+        //  Send reply back to client
+        zstr.send[receiver; "World"]];
+    zsocket.destroy[ctx; receiver];
+    :0N}
+
+ctx:zctx.new[]
+
+//  Socket to talk to clients
+clients:zsocket.new[ctx; zmq.ROUTER]
+clientsport:zsocket.bind[clients; `$"tcp://*:5555"]
+
+//  Socket to talk to workers
+workers:zsocket.new[ctx; zmq.DEALER]
+workersport:zsocket.bind[workers; `inproc://workers]
+
+//  Launch pool of worker threads
+do[5; zthread.fork[ctx; `worker_routine; 0]]
+//  Connect work threads to client threads via a queue
+rc:libzmq.device[zmq.QUEUE; clients; workers]
+if[rc<>-1; '`fail]
+
+//  We never get here but clean up anyhow
+zsocket.destroy[ctx; clients]
+zsocket.destroy[ctx; workers]
+zctx.destroy[ctx]
+\\

--- a/examples/Q/version.q
+++ b/examples/Q/version.q
@@ -1,0 +1,5 @@
+//  Report 0MQ version
+\l qzmq.q
+mnp:libzmq.version[]
+zclock.log "Current 0MQ version is ","." sv (string mnp)
+\\


### PR DESCRIPTION
Examples in Q. Uses qzmq or https://github.com/jaeheum/qzmq.
qzmq follows czmq rather than libzmq and examples here are translations from libzmq to czmq/qzmq.

(More examples to come.)
