### PR TITLE
Update examples/C/zhelpers.h

### DIFF
--- a/examples/C/zhelpers.h
+++ b/examples/C/zhelpers.h
@@ -107,6 +107,7 @@ s_dump (void *socket)
         printf ("\n");
 
         int64_t more;           //  Multipart detection
+        more = 0;
         size_t more_size = sizeof (more);
         zmq_getsockopt (socket, ZMQ_RCVMORE, &more, &more_size);
         zmq_msg_close (&message);


### PR DESCRIPTION
in fun s_dump, variable more doesn't initialized
On my 64-bit computer, fun zmq_getsockopt only assign value to lower four bytes
