### PR TITLE
Fix assertion in C# lruqueue2

### DIFF
--- a/examples/C#/lruqueue2.cs
+++ b/examples/C#/lruqueue2.cs
@@ -27,11 +27,11 @@ namespace ZMQGuide
             {
                 using (var client = ctx.Socket(SocketType.REQ))
                 {
+                    ZHelpers.SetID(client, Encoding.Unicode);
+                    client.Connect("tcp://localhost:5555");
+
                     while (true)
                     {
-                        ZHelpers.SetID(client, Encoding.Unicode);
-                        client.Connect("tcp://localhost:5555");
-
                         //  Send request, get repl
                         client.Send("HELLO", Encoding.Unicode);
                         string reply = client.Recv(Encoding.Unicode);


### PR DESCRIPTION
Previously, the client task would set its identity and connect to the frontend _inside_ of its work loop, which would cause an assertion in select.cpp (`fds.size () <= FD_SETSIZE`) because the fds set would spill past the 1024 limit.

The identity and connect statements have been moved outside of the loop, preventing this error.
