### PR TITLE
python example syncsub missing sleep() 

### DIFF
--- a/examples/Python/syncsub.py
+++ b/examples/Python/syncsub.py
@@ -1,6 +1,8 @@
 #
 #  Synchronized subscriber
 #
+import time
+
 import zmq
 
 def main():
@@ -10,6 +12,8 @@ def main():
     subscriber = context.socket(zmq.SUB)
     subscriber.connect('tcp://localhost:5561')
     subscriber.setsockopt(zmq.SUBSCRIBE, "")
+
+    time.sleep(1)
 
     # Second, synchronize with publisher
     syncclient = context.socket(zmq.REQ)


### PR DESCRIPTION
added time.sleep() between subscription and REQ/REP
it is mentioned in the manual and is in the C example
