### PR TITLE
修改异常处理的错误，抛异常的时候会把中断标志也清除的，所以要重新设置（see detains for English）

### DIFF
--- a/examples/Java/mthwserver.java
+++ b/examples/Java/mthwserver.java
@@ -36,6 +36,7 @@ public class mthwserver {
 	            }
 	            catch(InterruptedException e){
 	                e.printStackTrace();
+	                Thread.currentThread().interrupt();
 	            }
 
 	            //  Send reply back to client


### PR DESCRIPTION
when a InterruptedException is thrown, the interrupt status is also cleared.
we should restore the interrupt status after catch the InterruptedException.
refernece  http://docs.oracle.com/javase/6/docs/api/java/lang/Thread.html#interrupt()
