### PR TITLE
Use zmq::proxy rather than zmq::device

### DIFF
--- a/examples/C++/mtserver.cpp
+++ b/examples/C++/mtserver.cpp
@@ -49,7 +49,7 @@ int main ()
         pthread_create (&worker, NULL, worker_routine, (void *) &context);
     }
     //  Connect work threads to client threads via a queue
-    zmq::device (ZMQ_QUEUE, clients, workers);
+    zmq::proxy (clients, workers, NULL);
     return 0;
 }
     


### PR DESCRIPTION
With the current version of cppzmq, `mtserver.cpp` fails to build:

```
mtserver.cpp: In function 'int main()':
mtserver.cpp:52:5: error: 'device' is not a member of 'zmq'
```

The solution is to use `zmq::proxy` instead. Note that this requires a recent version of cppzmq (at least https://github.com/zeromq/cppzmq/commit/34dd3a1f3630085f6da77bbae8c41289eb23d179).
