### PR TITLE
More C# examples fixed

### DIFF
--- a/examples/C#/ZHelpers.cs
+++ b/examples/C#/ZHelpers.cs
@@ -31,7 +31,9 @@ namespace zguide
 
         public static string SetID(ZmqSocket client, Encoding unicode)
         {
-            throw new NotImplementedException();
+            var str = client.GetHashCode().ToString();
+            client.Identity = unicode.GetBytes(str);
+            return str;
         }
 
         public static bool Version()

--- a/examples/C#/asyncsrv.cs
+++ b/examples/C#/asyncsrv.cs
@@ -48,8 +48,7 @@ namespace zguide.asycnsrv
                 using (ZmqSocket client = context.CreateSocket(SocketType.DEALER))
                 {
                     //  Generate printable identity for the client
-                    ZHelpers.SetID(client, Encoding.Unicode);
-                    string identity = Encoding.Unicode.GetString(client.Identity);
+                    string identity = ZHelpers.SetID(client, Encoding.Unicode);
                     client.Connect("tcp://localhost:5570");
 
                     client.ReceiveReady += (s, e) =>
@@ -67,7 +66,7 @@ namespace zguide.asycnsrv
                         //  Tick once per second, pulling in arriving messages
                         for (int centitick = 0; centitick < 100; centitick++)
                         {
-                            poller.Poll(TimeSpan.FromMilliseconds(10000));
+                            poller.Poll(TimeSpan.FromMilliseconds(10));
                         }
                         var zmsg = new ZMessage("");
                         zmsg.StringToBody(String.Format("request: {0}", ++requestNumber));


### PR DESCRIPTION
ZHelpers.SetID() was not implemented and just throws an exception. It is used in seven examples.

In asyncsrv the polling is 10 seconds instead of 10 milliseconds (see ZMQ_POLL_MSEC in http://www.zeromq.org/docs:3-1-upgrade).
