### PR TITLE
Simplify the ruby req/rep broker example

### DIFF
--- a/examples/Ruby/rrbroker.rb
+++ b/examples/Ruby/rrbroker.rb
@@ -19,19 +19,11 @@ loop do
   poller.poll(:blocking)
   poller.readables.each do |socket|
     if socket === frontend
-      loop do
-        socket.recv_string(message = '')
-        more = socket.more_parts?
-        backend.send_string(message, more ? ZMQ::SNDMORE : 0)
-        break unless more
-      end
+      socket.recv_strings(messages = [])
+      backend.send_strings(messages)
     elsif socket === backend
-      loop do
-        socket.recv_string(message = '')
-        more = socket.more_parts?
-        frontend.send_string(message, more ? ZMQ::SNDMORE : 0)
-        break unless more
-      end
+      socket.recv_strings(messages = [])
+      frontend.send_strings(messages)
     end
   end
 end


### PR DESCRIPTION
Using `ZMQ::Socket#recv_strings` and `ZMQ::Socket#send_strings` allows removal of the somewhat awkward internal loop.
