### PR TITLE
Normalize formatting in Go examples.

### DIFF
--- a/examples/Go/identity.go
+++ b/examples/Go/identity.go
@@ -6,26 +6,28 @@
 package main
 
 import (
-	zmq "github.com/alecthomas/gozmq"
 	"fmt"
+	zmq "github.com/alecthomas/gozmq"
 )
 
 func dump(sink zmq.Socket) {
 	parts, err := sink.RecvMultipart(0)
-	if err != nil { fmt.Println(err) }
+	if err != nil {
+		fmt.Println(err)
+	}
 	for _, msgdata := range parts {
-	  is_text := true
-	  fmt.Printf("[%03d] ", len(msgdata))
-	  for _, char := range msgdata {
-		if char < 32 || char > 127 {
-		  is_text = false
+		is_text := true
+		fmt.Printf("[%03d] ", len(msgdata))
+		for _, char := range msgdata {
+			if char < 32 || char > 127 {
+				is_text = false
+			}
 		}
-	  }
-	  if is_text {
-		fmt.Printf("%s\n", msgdata)
-	  } else {
-		fmt.Printf("%X\n", msgdata)
-	  }
+		if is_text {
+			fmt.Printf("%s\n", msgdata)
+		} else {
+			fmt.Printf("%X\n", msgdata)
+		}
 	}
 }
 
@@ -34,23 +36,31 @@ func main() {
 	defer context.Close()
 
 	sink, err := context.NewSocket(zmq.ROUTER)
-	if err != nil { print(err) }
+	if err != nil {
+		print(err)
+	}
 	defer sink.Close()
 	sink.Bind("inproc://example")
 
 	// First allow 0MQ to set the identity
 	anonymous, err := context.NewSocket(zmq.REQ)
 	defer anonymous.Close()
-	if err != nil { fmt.Println(err) }
+	if err != nil {
+		fmt.Println(err)
+	}
 	anonymous.Connect("inproc://example")
 	err = anonymous.Send([]byte("ROUTER uses a generated UUID"), 0)
-	if err != nil { fmt.Println(err) }
+	if err != nil {
+		fmt.Println(err)
+	}
 
 	dump(sink)
 
 	//  Then set the identity ourselves
 	identified, err := context.NewSocket(zmq.REQ)
-	if err != nil { print(err) }
+	if err != nil {
+		print(err)
+	}
 	defer identified.Close()
 	identified.SetSockOptString(zmq.IDENTITY, "PEER2")
 	identified.Connect("inproc://example")

--- a/examples/Go/lpclient.go
+++ b/examples/Go/lpclient.go
@@ -8,75 +8,75 @@
 package main
 
 import (
-    "fmt"
-    "strconv"
-    zmq "github.com/alecthomas/gozmq"
+	"fmt"
+	zmq "github.com/alecthomas/gozmq"
+	"strconv"
 )
 
 const (
-    REQUEST_TIMEOUT = 2500 * 1000
-    REQUEST_RETRIES = 3
-    SERVER_ENDPOINT = "tcp://localhost:5555"
+	REQUEST_TIMEOUT = 2500 * 1000
+	REQUEST_RETRIES = 3
+	SERVER_ENDPOINT = "tcp://localhost:5555"
 )
 
 func main() {
-    context, _ := zmq.NewContext()
-    defer context.Close()
+	context, _ := zmq.NewContext()
+	defer context.Close()
 
-    fmt.Println("I: Connecting to server...")
-    client, _ := context.NewSocket(zmq.REQ)
+	fmt.Println("I: Connecting to server...")
+	client, _ := context.NewSocket(zmq.REQ)
 
-    client.Connect(SERVER_ENDPOINT)
+	client.Connect(SERVER_ENDPOINT)
 
-    for sequence, retriesLeft := 1, REQUEST_RETRIES; retriesLeft > 0; sequence ++ {
-        fmt.Printf("I: Sending (%d)\n", sequence)
-        client.Send([]byte(strconv.Itoa(sequence)), 0)
+	for sequence, retriesLeft := 1, REQUEST_RETRIES; retriesLeft > 0; sequence++ {
+		fmt.Printf("I: Sending (%d)\n", sequence)
+		client.Send([]byte(strconv.Itoa(sequence)), 0)
 
-        for expectReply := true; expectReply; {
-            //  Poll socket for a reply, with timeout
-            items := zmq.PollItems{
-                zmq.PollItem{Socket: client, Events: zmq.POLLIN},
-            }
-            if _, err := zmq.Poll(items, REQUEST_TIMEOUT); err != nil {
-                panic(err)      //  Interrupted
-            }
+		for expectReply := true; expectReply; {
+			//  Poll socket for a reply, with timeout
+			items := zmq.PollItems{
+				zmq.PollItem{Socket: client, Events: zmq.POLLIN},
+			}
+			if _, err := zmq.Poll(items, REQUEST_TIMEOUT); err != nil {
+				panic(err) //  Interrupted
+			}
 
-            //  .split process server reply
-            //  Here we process a server reply and exit our loop if the
-            //  reply is valid. If we didn't a reply we close the client
-            //  socket and resend the request. We try a number of times
-            //  before finally abandoning:
+			//  .split process server reply
+			//  Here we process a server reply and exit our loop if the
+			//  reply is valid. If we didn't a reply we close the client
+			//  socket and resend the request. We try a number of times
+			//  before finally abandoning:
 
-            if item := items[0]; item.REvents&zmq.POLLIN != 0 {
-                //  We got a reply from the server, must match sequence
-                reply, err := item.Socket.Recv(0)
-                if err != nil {
-                    panic(err)      //  Interrupted
-                }
+			if item := items[0]; item.REvents&zmq.POLLIN != 0 {
+				//  We got a reply from the server, must match sequence
+				reply, err := item.Socket.Recv(0)
+				if err != nil {
+					panic(err) //  Interrupted
+				}
 
-                if replyInt, err := strconv.Atoi(string(reply)); replyInt == sequence && err == nil {
-                    fmt.Printf("I: Server replied OK (%s)\n", reply)
-                    retriesLeft = REQUEST_RETRIES
-                    expectReply = false
-                } else {
-                    fmt.Printf("E: Malformed reply from server: %s", reply)
-                }
-            } else if retriesLeft --; retriesLeft == 0 {
-                fmt.Println("E: Server seems to be offline, abandoning")
-                client.SetSockOptInt(zmq.LINGER, 0)
-                client.Close()
-                break
-            } else {
-                fmt.Println("W: No response from server, retrying...")
-                //  Old socket is confused; close it and open a new one
-                client.SetSockOptInt(zmq.LINGER, 0)
-                client.Close()
-                client, _ = context.NewSocket(zmq.REQ)
-                client.Connect(SERVER_ENDPOINT)
-                fmt.Printf("I: Resending (%d)\n", sequence)
-                //  Send request again, on new socket
-                client.Send([]byte(strconv.Itoa(sequence)), 0)
-            }
-        }
-    }
+				if replyInt, err := strconv.Atoi(string(reply)); replyInt == sequence && err == nil {
+					fmt.Printf("I: Server replied OK (%s)\n", reply)
+					retriesLeft = REQUEST_RETRIES
+					expectReply = false
+				} else {
+					fmt.Printf("E: Malformed reply from server: %s", reply)
+				}
+			} else if retriesLeft--; retriesLeft == 0 {
+				fmt.Println("E: Server seems to be offline, abandoning")
+				client.SetSockOptInt(zmq.LINGER, 0)
+				client.Close()
+				break
+			} else {
+				fmt.Println("W: No response from server, retrying...")
+				//  Old socket is confused; close it and open a new one
+				client.SetSockOptInt(zmq.LINGER, 0)
+				client.Close()
+				client, _ = context.NewSocket(zmq.REQ)
+				client.Connect(SERVER_ENDPOINT)
+				fmt.Printf("I: Resending (%d)\n", sequence)
+				//  Send request again, on new socket
+				client.Send([]byte(strconv.Itoa(sequence)), 0)
+			}
+		}
+	}
 }

--- a/examples/Go/lpserver.go
+++ b/examples/Go/lpserver.go
@@ -7,47 +7,46 @@
 //  Author: iano <scaly.iano@gmail.com>
 //  Based on C example
 
-
 package main
 
 import (
-    "fmt"
-    "math/rand"
-    "time"
-    zmq "github.com/alecthomas/gozmq"
+	"fmt"
+	zmq "github.com/alecthomas/gozmq"
+	"math/rand"
+	"time"
 )
 
 const (
-    SERVER_ENDPOINT = "tcp://*:5555"
+	SERVER_ENDPOINT = "tcp://*:5555"
 )
 
 func main() {
-    src := rand.NewSource(time.Now().UnixNano())
-    random := rand.New(src)
+	src := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(src)
 
-    context, _ := zmq.NewContext()
-    defer context.Close()
+	context, _ := zmq.NewContext()
+	defer context.Close()
 
-    server, _ := context.NewSocket(zmq.REP)
-    defer server.Close()
-    server.Bind(SERVER_ENDPOINT)
+	server, _ := context.NewSocket(zmq.REP)
+	defer server.Close()
+	server.Bind(SERVER_ENDPOINT)
 
-    for cycles := 1;; cycles ++ {
-        request, _ := server.Recv(0)
+	for cycles := 1; ; cycles++ {
+		request, _ := server.Recv(0)
 
-        //  Simulate various problems, after a few cycles
-        if cycles > 3 {
-            switch r := random.Intn(3); r {
-            case 0:
-                fmt.Println("I: Simulating a crash")
-                return
-            case 1:
-                fmt.Println("I: simulating CPU overload")
-                time.Sleep(2 * time.Second)
-            }
-        }
-        fmt.Printf("I: normal request (%s)\n", request)
-        time.Sleep(1 * time.Second)     //  Do some heavy work
-        server.Send(request, 0)
-    }
+		//  Simulate various problems, after a few cycles
+		if cycles > 3 {
+			switch r := random.Intn(3); r {
+			case 0:
+				fmt.Println("I: Simulating a crash")
+				return
+			case 1:
+				fmt.Println("I: simulating CPU overload")
+				time.Sleep(2 * time.Second)
+			}
+		}
+		fmt.Printf("I: normal request (%s)\n", request)
+		time.Sleep(1 * time.Second) //  Do some heavy work
+		server.Send(request, 0)
+	}
 }

--- a/examples/Go/mdbroker.go
+++ b/examples/Go/mdbroker.go
@@ -11,307 +11,306 @@
 package main
 
 import (
-    "encoding/hex"
-    "log"
-    "os"
-    "time"
-    zmq "github.com/alecthomas/gozmq"
+	"encoding/hex"
+	zmq "github.com/alecthomas/gozmq"
+	"log"
+	"os"
+	"time"
 )
 
 const (
-    INTERNAL_SERVICE_PREFIX = "mmi."
-    HEARTBEAT_LIVENESS = 3
-    HEARTBEAT_INTERVAL = 2500 * time.Millisecond
-    HEARTBEAT_EXPIRY = HEARTBEAT_INTERVAL * HEARTBEAT_LIVENESS
+	INTERNAL_SERVICE_PREFIX = "mmi."
+	HEARTBEAT_LIVENESS      = 3
+	HEARTBEAT_INTERVAL      = 2500 * time.Millisecond
+	HEARTBEAT_EXPIRY        = HEARTBEAT_INTERVAL * HEARTBEAT_LIVENESS
 )
 
 type Broker interface {
-    Close()
-    Run()
+	Close()
+	Run()
 }
 
 type mdWorker struct {
-    identity string     //  Hex Identity of worker
-    address []byte      //  Address to route to
-    expiry time.Time    //  Expires at this point, unless heartbeat
-    service *mdService  //  Owning service, if known
+	identity string     //  Hex Identity of worker
+	address  []byte     //  Address to route to
+	expiry   time.Time  //  Expires at this point, unless heartbeat
+	service  *mdService //  Owning service, if known
 }
 
 type mdService struct {
-    broker Broker
-    name string
-    requests [][][]byte //  List of client requests
-    waiting *ZList      //  List of waiting workers
+	broker   Broker
+	name     string
+	requests [][][]byte //  List of client requests
+	waiting  *ZList     //  List of waiting workers
 }
 
 type mdBroker struct {
-    context zmq.Context             //  Context
-    heartbeatAt time.Time           //  When to send HEARTBEAT
-    services map[string]*mdService  //  Known services
-    socket zmq.Socket               //  Socket for clients & workers
-    waiting *ZList                  //  Idle workers
-    workers map[string]*mdWorker    //  Known workers
-    verbose bool                    //  Print activity to stdout
+	context     zmq.Context           //  Context
+	heartbeatAt time.Time             //  When to send HEARTBEAT
+	services    map[string]*mdService //  Known services
+	socket      zmq.Socket            //  Socket for clients & workers
+	waiting     *ZList                //  Idle workers
+	workers     map[string]*mdWorker  //  Known workers
+	verbose     bool                  //  Print activity to stdout
 }
 
 func NewBroker(endpoint string, verbose bool) Broker {
-    context, _ := zmq.NewContext()
-    socket, _ := context.NewSocket(zmq.ROUTER)
-    socket.SetSockOptInt(zmq.LINGER, 0)
-    socket.Bind(endpoint)
-    log.Printf("I: MDP broker/0.1.1 is active at %s\n", endpoint)
-    return &mdBroker{
-        context: context,
-        heartbeatAt: time.Now().Add(HEARTBEAT_INTERVAL),
-        services: make(map[string]*mdService),
-        socket: socket,
-        waiting: NewList(),
-        workers: make(map[string]*mdWorker),
-        verbose: verbose,
-    }
+	context, _ := zmq.NewContext()
+	socket, _ := context.NewSocket(zmq.ROUTER)
+	socket.SetSockOptInt(zmq.LINGER, 0)
+	socket.Bind(endpoint)
+	log.Printf("I: MDP broker/0.1.1 is active at %s\n", endpoint)
+	return &mdBroker{
+		context:     context,
+		heartbeatAt: time.Now().Add(HEARTBEAT_INTERVAL),
+		services:    make(map[string]*mdService),
+		socket:      socket,
+		waiting:     NewList(),
+		workers:     make(map[string]*mdWorker),
+		verbose:     verbose,
+	}
 }
 
 //  Deletes worker from all data structures, and deletes worker.
 func (self *mdBroker) deleteWorker(worker *mdWorker, disconnect bool) {
-    if worker == nil {
-        panic("Nil worker")
-    }
+	if worker == nil {
+		panic("Nil worker")
+	}
 
-    if disconnect {
-        self.sendToWorker(worker, MDPW_DISCONNECT, nil, nil)
-    }
+	if disconnect {
+		self.sendToWorker(worker, MDPW_DISCONNECT, nil, nil)
+	}
 
-    if worker.service != nil {
-        worker.service.waiting.Delete(worker)
-    }
-    self.waiting.Delete(worker)
-    delete(self.workers, worker.identity)
+	if worker.service != nil {
+		worker.service.waiting.Delete(worker)
+	}
+	self.waiting.Delete(worker)
+	delete(self.workers, worker.identity)
 }
 
 //  Dispatch requests to waiting workers as possible
 func (self *mdBroker) dispatch(service *mdService, msg [][]byte) {
-    if service == nil {
-        panic("Nil service")
-    }
-    //  Queue message if any
-    if len(msg) != 0 {
-        service.requests = append(service.requests, msg)
-    }
-    self.purgeWorkers()
-    for service.waiting.Len() > 0 && len(service.requests) > 0 {
-        msg, service.requests = service.requests[0], service.requests[1:]
-        elem := service.waiting.Pop()
-        self.waiting.Remove(elem)
-        worker, _ := elem.Value.(*mdWorker)
-        self.sendToWorker(worker, MDPW_REQUEST, nil, msg)
-    }
+	if service == nil {
+		panic("Nil service")
+	}
+	//  Queue message if any
+	if len(msg) != 0 {
+		service.requests = append(service.requests, msg)
+	}
+	self.purgeWorkers()
+	for service.waiting.Len() > 0 && len(service.requests) > 0 {
+		msg, service.requests = service.requests[0], service.requests[1:]
+		elem := service.waiting.Pop()
+		self.waiting.Remove(elem)
+		worker, _ := elem.Value.(*mdWorker)
+		self.sendToWorker(worker, MDPW_REQUEST, nil, msg)
+	}
 }
 
 // Process a request coming from a client.
 func (self *mdBroker) processClient(sender []byte, msg [][]byte) {
-    //  Service name + body
-    if len(msg) < 2 {
-        panic("Invalid msg")
-    }
-    service := msg[0]
-    //  Set reply return address to client sender
-    msg = append([][]byte{sender, nil}, msg[1:]...)
-    if string(service[:4]) == INTERNAL_SERVICE_PREFIX {
-        self.serviceInternal(service, msg)
-    } else {
-        self.dispatch(self.requireService(string(service)), msg)
-    }
+	//  Service name + body
+	if len(msg) < 2 {
+		panic("Invalid msg")
+	}
+	service := msg[0]
+	//  Set reply return address to client sender
+	msg = append([][]byte{sender, nil}, msg[1:]...)
+	if string(service[:4]) == INTERNAL_SERVICE_PREFIX {
+		self.serviceInternal(service, msg)
+	} else {
+		self.dispatch(self.requireService(string(service)), msg)
+	}
 }
 
 //  Process message sent to us by a worker.
 func (self *mdBroker) processWorker(sender []byte, msg [][]byte) {
-    //  At least, command
-    if len(msg) < 1 {
-        panic("Invalid msg")
-    }
+	//  At least, command
+	if len(msg) < 1 {
+		panic("Invalid msg")
+	}
 
-    command, msg := msg[0], msg[1:]
-    identity := hex.EncodeToString(sender)
-    worker, workerReady := self.workers[identity]
-    if !workerReady {
-        worker = &mdWorker{
-            identity: identity,
-            address: sender,
-            expiry: time.Now().Add(HEARTBEAT_EXPIRY),
-        }
-        self.workers[identity] = worker
-        if self.verbose {
-            log.Printf("I: registering new worker: %s\n", identity)
-        }
-    }
+	command, msg := msg[0], msg[1:]
+	identity := hex.EncodeToString(sender)
+	worker, workerReady := self.workers[identity]
+	if !workerReady {
+		worker = &mdWorker{
+			identity: identity,
+			address:  sender,
+			expiry:   time.Now().Add(HEARTBEAT_EXPIRY),
+		}
+		self.workers[identity] = worker
+		if self.verbose {
+			log.Printf("I: registering new worker: %s\n", identity)
+		}
+	}
 
-    switch string(command) {
-    case MDPW_READY:
-        //  At least, a service name
-        if len(msg) < 1 {
-            panic("Invalid msg")
-        }
-        service := msg[0]
-        //  Not first command in session or Reserved service name
-        if workerReady || string(service[:4]) == INTERNAL_SERVICE_PREFIX {
-            self.deleteWorker(worker, true)
-        } else {
-            //  Attach worker to service and mark as idle
-            worker.service = self.requireService(string(service))
-            self.workerWaiting(worker)
-        }
-    case MDPW_REPLY:
-        if workerReady {
-            //  Remove & save client return envelope and insert the
-            //  protocol header and service name, then rewrap envelope.
-            client := msg[0]
-            msg = append([][]byte{client, nil, []byte(MDPC_CLIENT), []byte(worker.service.name)}, msg[2:]...)
-            self.socket.SendMultipart(msg, 0)
-            self.workerWaiting(worker)
-        } else {
-            self.deleteWorker(worker, true)
-        }
-    case MDPW_HEARTBEAT:
-        if workerReady {
-            worker.expiry = time.Now().Add(HEARTBEAT_EXPIRY)
-        } else {
-            self.deleteWorker(worker, true)
-        }
-    case MDPW_DISCONNECT:
-        self.deleteWorker(worker, false)
-    default:
-        log.Println("E: invalid message:")
-        Dump(msg)
-    }
+	switch string(command) {
+	case MDPW_READY:
+		//  At least, a service name
+		if len(msg) < 1 {
+			panic("Invalid msg")
+		}
+		service := msg[0]
+		//  Not first command in session or Reserved service name
+		if workerReady || string(service[:4]) == INTERNAL_SERVICE_PREFIX {
+			self.deleteWorker(worker, true)
+		} else {
+			//  Attach worker to service and mark as idle
+			worker.service = self.requireService(string(service))
+			self.workerWaiting(worker)
+		}
+	case MDPW_REPLY:
+		if workerReady {
+			//  Remove & save client return envelope and insert the
+			//  protocol header and service name, then rewrap envelope.
+			client := msg[0]
+			msg = append([][]byte{client, nil, []byte(MDPC_CLIENT), []byte(worker.service.name)}, msg[2:]...)
+			self.socket.SendMultipart(msg, 0)
+			self.workerWaiting(worker)
+		} else {
+			self.deleteWorker(worker, true)
+		}
+	case MDPW_HEARTBEAT:
+		if workerReady {
+			worker.expiry = time.Now().Add(HEARTBEAT_EXPIRY)
+		} else {
+			self.deleteWorker(worker, true)
+		}
+	case MDPW_DISCONNECT:
+		self.deleteWorker(worker, false)
+	default:
+		log.Println("E: invalid message:")
+		Dump(msg)
+	}
 }
 
 //  Look for & kill expired workers.
 //  Workers are oldest to most recent, so we stop at the first alive worker.
 func (self *mdBroker) purgeWorkers() {
-    now := time.Now()
-    for elem := self.waiting.Front(); elem != nil; elem = self.waiting.Front() {
-        worker, _ := elem.Value.(*mdWorker)
-        if worker.expiry.After(now) {
-            break
-        }
-        self.deleteWorker(worker, false)
-    }
+	now := time.Now()
+	for elem := self.waiting.Front(); elem != nil; elem = self.waiting.Front() {
+		worker, _ := elem.Value.(*mdWorker)
+		if worker.expiry.After(now) {
+			break
+		}
+		self.deleteWorker(worker, false)
+	}
 }
 
 //  Locates the service (creates if necessary).
-func(self *mdBroker) requireService(name string) *mdService {
-    if len(name) == 0 {
-        panic("Invalid service name")
-    }
-    service, ok := self.services[name];
-    if !ok {
-        service = &mdService{
-            name: name,
-            waiting: NewList(),
-        }
-        self.services[name] = service
-    }
-    return service
+func (self *mdBroker) requireService(name string) *mdService {
+	if len(name) == 0 {
+		panic("Invalid service name")
+	}
+	service, ok := self.services[name]
+	if !ok {
+		service = &mdService{
+			name:    name,
+			waiting: NewList(),
+		}
+		self.services[name] = service
+	}
+	return service
 }
 
 //  Send message to worker.
 //  If message is provided, sends that message.
 func (self *mdBroker) sendToWorker(worker *mdWorker, command string, option []byte, msg [][]byte) {
-    //  Stack routing and protocol envelopes to start of message and routing envelope
-    if len(option) > 0 {
-        msg = append([][]byte{option}, msg...)
-    }
-    msg = append([][]byte{worker.address, nil, []byte(MDPW_WORKER), []byte(command)}, msg...)
+	//  Stack routing and protocol envelopes to start of message and routing envelope
+	if len(option) > 0 {
+		msg = append([][]byte{option}, msg...)
+	}
+	msg = append([][]byte{worker.address, nil, []byte(MDPW_WORKER), []byte(command)}, msg...)
 
-    if self.verbose {
-        log.Printf("I: sending %X to worker\n", command)
-        Dump(msg)
-    }
-    self.socket.SendMultipart(msg, 0)
+	if self.verbose {
+		log.Printf("I: sending %X to worker\n", command)
+		Dump(msg)
+	}
+	self.socket.SendMultipart(msg, 0)
 }
 
 //  Handle internal service according to 8/MMI specification
 func (self *mdBroker) serviceInternal(service []byte, msg [][]byte) {
-    returncode := "501"
-    if string(service) == "mmi.service" {
-        name := string(msg[len(msg)-1])
-        if _, ok := self.services[name]; ok {
-            returncode = "200"
-        } else {
-            returncode = "404"
-        }
-    }
-    msg[len(msg)-1] = []byte(returncode)
-    //  insert the protocol header and service name after the routing envelope
-    msg = append(append(msg[2:], []byte(MDPC_CLIENT), service), msg[3:]...)
-    self.socket.SendMultipart(msg, 0)
+	returncode := "501"
+	if string(service) == "mmi.service" {
+		name := string(msg[len(msg)-1])
+		if _, ok := self.services[name]; ok {
+			returncode = "200"
+		} else {
+			returncode = "404"
+		}
+	}
+	msg[len(msg)-1] = []byte(returncode)
+	//  insert the protocol header and service name after the routing envelope
+	msg = append(append(msg[2:], []byte(MDPC_CLIENT), service), msg[3:]...)
+	self.socket.SendMultipart(msg, 0)
 }
 
 //  This worker is now waiting for work.
 func (self *mdBroker) workerWaiting(worker *mdWorker) {
-    //  Queue to broker and service waiting lists
-    self.waiting.PushBack(worker)
-    worker.service.waiting.PushBack(worker)
-    worker.expiry = time.Now().Add(HEARTBEAT_EXPIRY)
-    self.dispatch(worker.service, nil)
+	//  Queue to broker and service waiting lists
+	self.waiting.PushBack(worker)
+	worker.service.waiting.PushBack(worker)
+	worker.expiry = time.Now().Add(HEARTBEAT_EXPIRY)
+	self.dispatch(worker.service, nil)
 }
 
 func (self *mdBroker) Close() {
-    if self.socket != nil {
-        self.socket.Close()
-    }
-    self.context.Close()
+	if self.socket != nil {
+		self.socket.Close()
+	}
+	self.context.Close()
 }
 
 //  Main broker working loop
 func (self *mdBroker) Run() {
-    for {
-        items := zmq.PollItems{
-            zmq.PollItem{Socket: self.socket, Events: zmq.POLLIN},
-        }
+	for {
+		items := zmq.PollItems{
+			zmq.PollItem{Socket: self.socket, Events: zmq.POLLIN},
+		}
 
-        _, err := zmq.Poll(items, HEARTBEAT_INTERVAL.Nanoseconds()/1e3)
-        if err != nil {
-            panic(err)      //  Interrupted
-        }
+		_, err := zmq.Poll(items, HEARTBEAT_INTERVAL.Nanoseconds()/1e3)
+		if err != nil {
+			panic(err) //  Interrupted
+		}
 
-        if item := items[0]; item.REvents&zmq.POLLIN != 0 {
-            msg, _ := self.socket.RecvMultipart(0)
-            if self.verbose {
-                log.Printf("I: received message:")
-                Dump(msg)
-            }
+		if item := items[0]; item.REvents&zmq.POLLIN != 0 {
+			msg, _ := self.socket.RecvMultipart(0)
+			if self.verbose {
+				log.Printf("I: received message:")
+				Dump(msg)
+			}
 
-            sender := msg[0]
-            header := msg[2]
-            msg = msg[3:]
+			sender := msg[0]
+			header := msg[2]
+			msg = msg[3:]
 
-            if string(header) == MDPC_CLIENT {
-                self.processClient(sender, msg)
-            } else if string(header) == MDPW_WORKER {
-                self.processWorker(sender, msg)
-            } else {
-                log.Println("E: invalid message:")
-                Dump(msg)
-            }
-        }
+			if string(header) == MDPC_CLIENT {
+				self.processClient(sender, msg)
+			} else if string(header) == MDPW_WORKER {
+				self.processWorker(sender, msg)
+			} else {
+				log.Println("E: invalid message:")
+				Dump(msg)
+			}
+		}
 
-        if self.heartbeatAt.Before(time.Now()) {
-            self.purgeWorkers()
-            for elem := self.waiting.Front(); elem != nil; elem = elem.Next() {
-                worker, _ := elem.Value.(*mdWorker)
-                self.sendToWorker(worker, MDPW_HEARTBEAT, nil, nil)
-            }
-            self.heartbeatAt = time.Now().Add(HEARTBEAT_INTERVAL)
-        }
-    }
+		if self.heartbeatAt.Before(time.Now()) {
+			self.purgeWorkers()
+			for elem := self.waiting.Front(); elem != nil; elem = elem.Next() {
+				worker, _ := elem.Value.(*mdWorker)
+				self.sendToWorker(worker, MDPW_HEARTBEAT, nil, nil)
+			}
+			self.heartbeatAt = time.Now().Add(HEARTBEAT_INTERVAL)
+		}
+	}
 }
 
-
 func main() {
-    verbose := len(os.Args) >= 2 && os.Args[1] == "-v"
-    broker := NewBroker("tcp://*:5555", verbose)
-    defer broker.Close()
+	verbose := len(os.Args) >= 2 && os.Args[1] == "-v"
+	broker := NewBroker("tcp://*:5555", verbose)
+	defer broker.Close()
 
-    broker.Run()
+	broker.Run()
 }

--- a/examples/Go/mdcliapi.go
+++ b/examples/Go/mdcliapi.go
@@ -7,112 +7,114 @@
 package main
 
 import (
-    "log"
-    "time"
-    zmq "github.com/alecthomas/gozmq"
+	zmq "github.com/alecthomas/gozmq"
+	"log"
+	"time"
 )
 
 type Client interface {
-    Close()
-    Send([]byte, [][]byte) [][]byte
+	Close()
+	Send([]byte, [][]byte) [][]byte
 }
 
 type mdClient struct {
-    broker string
-    client zmq.Socket
-    context zmq.Context
-    retries int
-    timeout time.Duration
-    verbose bool
+	broker  string
+	client  zmq.Socket
+	context zmq.Context
+	retries int
+	timeout time.Duration
+	verbose bool
 }
 
 func NewClient(broker string, verbose bool) Client {
-    context, _ := zmq.NewContext()
-    self := &mdClient{
-        broker: broker,
-        context: context,
-        retries: 3,
-        timeout: 2500 * time.Millisecond,
-        verbose: verbose,
-    }
-    self.reconnect()
-    return self
+	context, _ := zmq.NewContext()
+	self := &mdClient{
+		broker:  broker,
+		context: context,
+		retries: 3,
+		timeout: 2500 * time.Millisecond,
+		verbose: verbose,
+	}
+	self.reconnect()
+	return self
 }
 
 func (self *mdClient) reconnect() {
-    if self.client != nil {
-        self.client.Close()
-    }
+	if self.client != nil {
+		self.client.Close()
+	}
 
-    self.client, _ = self.context.NewSocket(zmq.REQ)
-    self.client.SetSockOptInt(zmq.LINGER, 0)
-    self.client.Connect(self.broker)
-    if self.verbose {
-        log.Printf("I: connecting to broker at %s...\n", self.broker)
-    }
+	self.client, _ = self.context.NewSocket(zmq.REQ)
+	self.client.SetSockOptInt(zmq.LINGER, 0)
+	self.client.Connect(self.broker)
+	if self.verbose {
+		log.Printf("I: connecting to broker at %s...\n", self.broker)
+	}
 }
 
 func (self *mdClient) Close() {
-    if self.client != nil {
-        self.client.Close()
-    }
-    self.context.Close()
+	if self.client != nil {
+		self.client.Close()
+	}
+	self.context.Close()
 }
 
-func (self *mdClient) Send(service []byte, request [][]byte) (reply [][]byte){
-    //  Prefix request with protocol frames
-    //  Frame 1: "MDPCxy" (six bytes, MDP/Client x.y)
-    //  Frame 2: Service name (printable string)
-    frame := append([][]byte{[]byte(MDPC_CLIENT), service}, request...)
-    if self.verbose {
-        log.Printf("I: send request to '%s' service:", service)
-        Dump(request)
-    }
+func (self *mdClient) Send(service []byte, request [][]byte) (reply [][]byte) {
+	//  Prefix request with protocol frames
+	//  Frame 1: "MDPCxy" (six bytes, MDP/Client x.y)
+	//  Frame 2: Service name (printable string)
+	frame := append([][]byte{[]byte(MDPC_CLIENT), service}, request...)
+	if self.verbose {
+		log.Printf("I: send request to '%s' service:", service)
+		Dump(request)
+	}
 
-    for retries := self.retries; retries > 0; {
-        self.client.SendMultipart(frame, 0)
-        items := zmq.PollItems{
-            zmq.PollItem{Socket: self.client, Events: zmq.POLLIN},
-        }
+	for retries := self.retries; retries > 0; {
+		self.client.SendMultipart(frame, 0)
+		items := zmq.PollItems{
+			zmq.PollItem{Socket: self.client, Events: zmq.POLLIN},
+		}
 
-        _, err := zmq.Poll(items, self.timeout.Nanoseconds()/1e3)
-        if err != nil {
-            panic(err)      //  Interrupted
-        }
+		_, err := zmq.Poll(items, self.timeout.Nanoseconds()/1e3)
+		if err != nil {
+			panic(err) //  Interrupted
+		}
 
-        if item := items[0]; item.REvents&zmq.POLLIN != 0 {
-            msg, _ := self.client.RecvMultipart(0)
-            if self.verbose {
-                log.Println("I: received reply: ")
-                Dump(msg)
-            }
+		if item := items[0]; item.REvents&zmq.POLLIN != 0 {
+			msg, _ := self.client.RecvMultipart(0)
+			if self.verbose {
+				log.Println("I: received reply: ")
+				Dump(msg)
+			}
 
-            //  We would handle malformed replies better in real code
-            if len(msg) < 3 {
-                panic("Error msg len")
-            }
+			//  We would handle malformed replies better in real code
+			if len(msg) < 3 {
+				panic("Error msg len")
+			}
 
-            header := msg[0]
-            if string(header) != MDPC_CLIENT {
-                panic("Error header")
-            }
+			header := msg[0]
+			if string(header) != MDPC_CLIENT {
+				panic("Error header")
+			}
 
-            replyService := msg[1]
-            if string(service) != string(replyService) { panic("Error reply service")}
+			replyService := msg[1]
+			if string(service) != string(replyService) {
+				panic("Error reply service")
+			}
 
-            reply = msg[2:]
-            break
-        } else if retries --; retries > 0 {
-            if self.verbose {
-                log.Println("W: no reply, reconnecting...")
-            }
-            self.reconnect()
-        } else {
-            if self.verbose {
-                log.Println("W: permanent error, abandoning")
-            }
-            break
-        }
-    }
-    return
+			reply = msg[2:]
+			break
+		} else if retries--; retries > 0 {
+			if self.verbose {
+				log.Println("W: no reply, reconnecting...")
+			}
+			self.reconnect()
+		} else {
+			if self.verbose {
+				log.Println("W: permanent error, abandoning")
+			}
+			break
+		}
+	}
+	return
 }

--- a/examples/Go/mdclient.go
+++ b/examples/Go/mdclient.go
@@ -8,25 +8,25 @@
 
 package main
 
-import(
-    "fmt"
-    "os"
+import (
+	"fmt"
+	"os"
 )
 
 func main() {
-    verbose := len(os.Args) >= 2 && os.Args[1] == "-v"
+	verbose := len(os.Args) >= 2 && os.Args[1] == "-v"
 
-    client := NewClient("tcp://localhost:5555", verbose)
-    defer client.Close()
+	client := NewClient("tcp://localhost:5555", verbose)
+	defer client.Close()
 
-    count := 0
-    for ; count < 1e5; count ++ {
-        request := [][]byte{[]byte("Hello world")}
-        reply := client.Send([]byte("echo"), request)
-        if len(reply) == 0 {
-            break
-        }
-    }
+	count := 0
+	for ; count < 1e5; count++ {
+		request := [][]byte{[]byte("Hello world")}
+		reply := client.Send([]byte("echo"), request)
+		if len(reply) == 0 {
+			break
+		}
+	}
 
-    fmt.Printf("%d requests/replies processed\n", count)
+	fmt.Printf("%d requests/replies processed\n", count)
 }

--- a/examples/Go/mdp.go
+++ b/examples/Go/mdp.go
@@ -5,18 +5,18 @@
 package main
 
 const (
-    //  This is the version of MDP/Client we implement
-    MDPC_CLIENT = "MDPC01"
+	//  This is the version of MDP/Client we implement
+	MDPC_CLIENT = "MDPC01"
 
-    //  This is the version of MDP/Worker we implement
-    MDPW_WORKER = "MDPW01"
+	//  This is the version of MDP/Worker we implement
+	MDPW_WORKER = "MDPW01"
 
-    //  MDP/Server commands, as strings
-    MDPW_READY      = "\001"
-    MDPW_REQUEST    = "\002"
-    MDPW_REPLY      = "\003"
-    MDPW_HEARTBEAT  = "\004"
-    MDPW_DISCONNECT = "\005"
+	//  MDP/Server commands, as strings
+	MDPW_READY      = "\001"
+	MDPW_REQUEST    = "\002"
+	MDPW_REPLY      = "\003"
+	MDPW_HEARTBEAT  = "\004"
+	MDPW_DISCONNECT = "\005"
 )
 
 var Commands = []string{"", "READY", "REQUEST", "REPLY", "HEARTBEAT", "DISCONNECT"}

--- a/examples/Go/mdworker.go
+++ b/examples/Go/mdworker.go
@@ -6,22 +6,21 @@
 //
 //  Author: iano <scaly.iano@gmail.com>
 
-
 package main
 
 import (
-    "os"
+	"os"
 )
 
 func main() {
-    verbose := len(os.Args) >= 2 && os.Args[1] == "-v"
+	verbose := len(os.Args) >= 2 && os.Args[1] == "-v"
 
-    worker := NewWorker("tcp://localhost:5555", "echo", verbose)
-    for reply := [][]byte{};; {
-        request := worker.Recv(reply)
-        if len(request) == 0 {
-            break
-        }
-        reply = request
-    }
+	worker := NewWorker("tcp://localhost:5555", "echo", verbose)
+	for reply := [][]byte{}; ; {
+		request := worker.Recv(reply)
+		if len(request) == 0 {
+			break
+		}
+		reply = request
+	}
 }

--- a/examples/Go/mdwrkapi.go
+++ b/examples/Go/mdwrkapi.go
@@ -7,159 +7,158 @@
 package main
 
 import (
-    "log"
-    "time"
-    zmq "github.com/alecthomas/gozmq"
+	zmq "github.com/alecthomas/gozmq"
+	"log"
+	"time"
 )
 
-const(
-    HEARTBEAT_LIVENESS = 3      //  3-5 is reasonable
+const (
+	HEARTBEAT_LIVENESS = 3 //  3-5 is reasonable
 )
 
 type Worker interface {
-    Close()
-    Recv([][]byte) [][]byte
+	Close()
+	Recv([][]byte) [][]byte
 }
 
 type mdWorker struct {
-    broker string
-    context zmq.Context
-    service string
-    verbose bool
-    worker zmq.Socket
+	broker  string
+	context zmq.Context
+	service string
+	verbose bool
+	worker  zmq.Socket
 
-    heartbeat time.Duration
-    heartbeatAt time.Time
-    liveness int
-    reconnect time.Duration
+	heartbeat   time.Duration
+	heartbeatAt time.Time
+	liveness    int
+	reconnect   time.Duration
 
-    expectReply bool
-    replyTo []byte
+	expectReply bool
+	replyTo     []byte
 }
 
 func NewWorker(broker, service string, verbose bool) Worker {
-    context, _ := zmq.NewContext()
-    self := &mdWorker{
-        broker: broker,
-        context: context,
-        service: service,
-        verbose: verbose,
-        heartbeat: 2500 * time.Millisecond,
-        liveness: 0,
-        reconnect: 2500 * time.Millisecond,
-    }
-    self.reconnectToBroker()
-    return self
+	context, _ := zmq.NewContext()
+	self := &mdWorker{
+		broker:    broker,
+		context:   context,
+		service:   service,
+		verbose:   verbose,
+		heartbeat: 2500 * time.Millisecond,
+		liveness:  0,
+		reconnect: 2500 * time.Millisecond,
+	}
+	self.reconnectToBroker()
+	return self
 }
 
 func (self *mdWorker) reconnectToBroker() {
-    if self.worker != nil {
-        self.worker.Close()
-    }
-    self.worker, _ = self.context.NewSocket(zmq.DEALER)
-    self.worker.SetSockOptInt(zmq.LINGER, 0)
-    self.worker.Connect(self.broker)
-    if self.verbose {
-        log.Printf("I: connecting to broker at %s...\n", self.broker)
-    }
-    self.sendToBroker(MDPW_READY, []byte(self.service), nil)
-    self.liveness = HEARTBEAT_LIVENESS
-    self.heartbeatAt = time.Now().Add(self.heartbeat)
+	if self.worker != nil {
+		self.worker.Close()
+	}
+	self.worker, _ = self.context.NewSocket(zmq.DEALER)
+	self.worker.SetSockOptInt(zmq.LINGER, 0)
+	self.worker.Connect(self.broker)
+	if self.verbose {
+		log.Printf("I: connecting to broker at %s...\n", self.broker)
+	}
+	self.sendToBroker(MDPW_READY, []byte(self.service), nil)
+	self.liveness = HEARTBEAT_LIVENESS
+	self.heartbeatAt = time.Now().Add(self.heartbeat)
 }
 
 func (self *mdWorker) sendToBroker(command string, option []byte, msg [][]byte) {
-    if len(option) > 0 {
-        msg = append([][]byte{option}, msg...)
-    }
+	if len(option) > 0 {
+		msg = append([][]byte{option}, msg...)
+	}
 
-    msg = append([][]byte{nil, []byte(MDPW_WORKER), []byte(command)}, msg...)
-    if self.verbose {
-        log.Printf("I: sending %X to broker\n", command)
-        Dump(msg)
-    }
-    self.worker.SendMultipart(msg, 0)
+	msg = append([][]byte{nil, []byte(MDPW_WORKER), []byte(command)}, msg...)
+	if self.verbose {
+		log.Printf("I: sending %X to broker\n", command)
+		Dump(msg)
+	}
+	self.worker.SendMultipart(msg, 0)
 }
 
 func (self *mdWorker) Close() {
-    if self.worker != nil {
-        self.worker.Close()
-    }
-    self.context.Close()
+	if self.worker != nil {
+		self.worker.Close()
+	}
+	self.context.Close()
 }
 
 func (self *mdWorker) Recv(reply [][]byte) (msg [][]byte) {
-    //  Format and send the reply if we were provided one
+	//  Format and send the reply if we were provided one
 
-    if len(reply) == 0 && self.expectReply {
-        panic("Error reply")
-    }
+	if len(reply) == 0 && self.expectReply {
+		panic("Error reply")
+	}
 
-    if len(reply) > 0 {
-        if len(self.replyTo) == 0{
-            panic("Error replyTo")
-        }
-        reply = append([][]byte{self.replyTo, nil}, reply...)
-        self.sendToBroker(MDPW_REPLY, nil, reply)
-    }
+	if len(reply) > 0 {
+		if len(self.replyTo) == 0 {
+			panic("Error replyTo")
+		}
+		reply = append([][]byte{self.replyTo, nil}, reply...)
+		self.sendToBroker(MDPW_REPLY, nil, reply)
+	}
 
-    self.expectReply = true
+	self.expectReply = true
 
-    for {
-        items := zmq.PollItems{
-            zmq.PollItem{Socket: self.worker, Events: zmq.POLLIN},
-        }
+	for {
+		items := zmq.PollItems{
+			zmq.PollItem{Socket: self.worker, Events: zmq.POLLIN},
+		}
 
-        _, err := zmq.Poll(items, self.heartbeat.Nanoseconds()/1e3)
-        if err != nil {
-            panic(err)      //  Interrupted
-        }
+		_, err := zmq.Poll(items, self.heartbeat.Nanoseconds()/1e3)
+		if err != nil {
+			panic(err) //  Interrupted
+		}
 
-        if item := items[0]; item.REvents&zmq.POLLIN != 0 {
-            msg, _ = self.worker.RecvMultipart(0)
-            if self.verbose {
-                log.Println("I: received message from broker: ")
-                Dump(msg)
-            }
-            self.liveness = HEARTBEAT_LIVENESS
-            if len(msg) < 3 {
-                panic("Invalid msg")        //  Interrupted
-            }
+		if item := items[0]; item.REvents&zmq.POLLIN != 0 {
+			msg, _ = self.worker.RecvMultipart(0)
+			if self.verbose {
+				log.Println("I: received message from broker: ")
+				Dump(msg)
+			}
+			self.liveness = HEARTBEAT_LIVENESS
+			if len(msg) < 3 {
+				panic("Invalid msg") //  Interrupted
+			}
 
-            header := msg[1]
-            if string(header) != MDPW_WORKER {
-                panic("Invalid header")     //  Interrupted
-            }
+			header := msg[1]
+			if string(header) != MDPW_WORKER {
+				panic("Invalid header") //  Interrupted
+			}
 
-            switch command := string(msg[2]); command {
-            case MDPW_REQUEST:
-                //  We should pop and save as many addresses as there are
-                //  up to a null part, but for now, just save one...
-                self.replyTo = msg[3]
-                msg = msg[5:]
-                return
-            case MDPW_HEARTBEAT:
-                // do nothin
-            case MDPW_DISCONNECT:
-                self.reconnectToBroker()
-            default:
-                log.Println("E: invalid input message:")
-                Dump(msg)
-            }
-        } else if self.liveness --; self.liveness <= 0{
-            if self.verbose {
-                log.Println("W: disconnected from broker - retrying...")
-            }
-            time.Sleep(self.reconnect)
-            self.reconnectToBroker()
-        }
+			switch command := string(msg[2]); command {
+			case MDPW_REQUEST:
+				//  We should pop and save as many addresses as there are
+				//  up to a null part, but for now, just save one...
+				self.replyTo = msg[3]
+				msg = msg[5:]
+				return
+			case MDPW_HEARTBEAT:
+				// do nothin
+			case MDPW_DISCONNECT:
+				self.reconnectToBroker()
+			default:
+				log.Println("E: invalid input message:")
+				Dump(msg)
+			}
+		} else if self.liveness--; self.liveness <= 0 {
+			if self.verbose {
+				log.Println("W: disconnected from broker - retrying...")
+			}
+			time.Sleep(self.reconnect)
+			self.reconnectToBroker()
+		}
 
-        //  Send HEARTBEAT if it's time
-        if self.heartbeatAt.Before(time.Now()) {
-            self.sendToBroker(MDPW_HEARTBEAT, nil, nil)
-            self.heartbeatAt = time.Now().Add(self.heartbeat)
-        }
-    }
+		//  Send HEARTBEAT if it's time
+		if self.heartbeatAt.Before(time.Now()) {
+			self.sendToBroker(MDPW_HEARTBEAT, nil, nil)
+			self.heartbeatAt = time.Now().Add(self.heartbeat)
+		}
+	}
 
-    return
+	return
 }
-

--- a/examples/Go/msgqueue.go
+++ b/examples/Go/msgqueue.go
@@ -7,25 +7,25 @@
 package main
 
 import (
-    zmq "github.com/alecthomas/gozmq"
+	zmq "github.com/alecthomas/gozmq"
 )
 
 func main() {
-    context, _ := zmq.NewContext()
+	context, _ := zmq.NewContext()
 	defer context.Close()
-    
-    // Socket facing clients
-    frontend, _ := context.NewSocket(zmq.ROUTER)
-    defer frontend.Close()
-    frontend.Bind("tcp://*:5559")
-    
-    // Socket facing services
-    backend, _ := context.NewSocket(zmq.DEALER)
-    defer backend.Close()
-    backend.Bind("tcp://*:5560")
-    
-    // Start built-in device
-    zmq.Device(zmq.QUEUE, frontend, backend)
-    
-    // We never get here...
+
+	// Socket facing clients
+	frontend, _ := context.NewSocket(zmq.ROUTER)
+	defer frontend.Close()
+	frontend.Bind("tcp://*:5559")
+
+	// Socket facing services
+	backend, _ := context.NewSocket(zmq.DEALER)
+	defer backend.Close()
+	backend.Bind("tcp://*:5560")
+
+	// Start built-in device
+	zmq.Device(zmq.QUEUE, frontend, backend)
+
+	// We never get here...
 }

--- a/examples/Go/mtrelay.go
+++ b/examples/Go/mtrelay.go
@@ -8,63 +8,61 @@
 package main
 
 import (
-    "fmt"
-    zmq "github.com/alecthomas/gozmq"
+	"fmt"
+	zmq "github.com/alecthomas/gozmq"
 )
 
 func main() {
-    // Prepare our context and sockets
-    context, _ := zmq.NewContext()
+	// Prepare our context and sockets
+	context, _ := zmq.NewContext()
 	defer context.Close()
-    
-    // Bind inproc socket before starting step2
-    receiver, _ := context.NewSocket(zmq.PAIR)
-    defer receiver.Close()
-    receiver.Bind("ipc://step3.ipc")
-    
-    go step2()
-    
-    // Wait for signal
-    receiver.Recv(0)
-    fmt.Println("Test successful!")
+
+	// Bind inproc socket before starting step2
+	receiver, _ := context.NewSocket(zmq.PAIR)
+	defer receiver.Close()
+	receiver.Bind("ipc://step3.ipc")
+
+	go step2()
+
+	// Wait for signal
+	receiver.Recv(0)
+	fmt.Println("Test successful!")
 }
 
 func step1() {
-    // Connect to step2 and tell it we're ready
-    context, _ := zmq.NewContext()
+	// Connect to step2 and tell it we're ready
+	context, _ := zmq.NewContext()
 	defer context.Close()
-    
-    xmitter, _ := context.NewSocket(zmq.PAIR)
-    defer xmitter.Close()
-    xmitter.Connect("ipc://step2.ipc")
-    
-    fmt.Println("Step 1 ready, signaling step 2")
-    
-    xmitter.Send([]byte("READY"), 0)
+
+	xmitter, _ := context.NewSocket(zmq.PAIR)
+	defer xmitter.Close()
+	xmitter.Connect("ipc://step2.ipc")
+
+	fmt.Println("Step 1 ready, signaling step 2")
+
+	xmitter.Send([]byte("READY"), 0)
 }
 
 func step2() {
-    context, _ := zmq.NewContext()
+	context, _ := zmq.NewContext()
 	defer context.Close()
-    
-    // Bind inproc before starting step 1
-    receiver, _ := context.NewSocket(zmq.PAIR)
-    defer receiver.Close()
-    receiver.Bind("ipc://step2.ipc")
-    
-    go step1()
-    
-    // wait for signal and pass it on
-    receiver.Recv(0)
-    
-    // Connect to step3 and tell it we're ready
-    xmitter, _ := context.NewSocket(zmq.PAIR)
-    defer xmitter.Close()
-    xmitter.Connect("ipc://step3.ipc")
-    
-    fmt.Println("Step 2 ready, singaling step 3")
-    
-    xmitter.Send([]byte("READY"), 0)
+
+	// Bind inproc before starting step 1
+	receiver, _ := context.NewSocket(zmq.PAIR)
+	defer receiver.Close()
+	receiver.Bind("ipc://step2.ipc")
+
+	go step1()
+
+	// wait for signal and pass it on
+	receiver.Recv(0)
+
+	// Connect to step3 and tell it we're ready
+	xmitter, _ := context.NewSocket(zmq.PAIR)
+	defer xmitter.Close()
+	xmitter.Connect("ipc://step3.ipc")
+
+	fmt.Println("Step 2 ready, singaling step 3")
+
+	xmitter.Send([]byte("READY"), 0)
 }
-
-

--- a/examples/Go/mtserver.go
+++ b/examples/Go/mtserver.go
@@ -8,53 +8,53 @@
 package main
 
 import (
-    "fmt"
-    "time"
-    zmq "github.com/alecthomas/gozmq"
+	"fmt"
+	zmq "github.com/alecthomas/gozmq"
+	"time"
 )
 
 func main() {
-    // Launch pool of worker threads
-    for i := 0;i != 5;i = i + 1 {
-        go worker()
-    }
-    
-    // Prepare our context and sockets
-    context, _ := zmq.NewContext()
+	// Launch pool of worker threads
+	for i := 0; i != 5; i = i + 1 {
+		go worker()
+	}
+
+	// Prepare our context and sockets
+	context, _ := zmq.NewContext()
 	defer context.Close()
-    
-    // Socket to talk to clients
-    clients, _ := context.NewSocket(zmq.ROUTER)
-    defer clients.Close()
-    clients.Bind("tcp://*:5555")
-    
-    // Socket to talk to workers
-    workers, _ := context.NewSocket(zmq.DEALER)
-    defer workers.Close()
-    workers.Bind("ipc://workers.ipc")
-    
-    // connect work threads to client threads via a queue
-    zmq.Device(zmq.QUEUE, clients, workers)
-    
+
+	// Socket to talk to clients
+	clients, _ := context.NewSocket(zmq.ROUTER)
+	defer clients.Close()
+	clients.Bind("tcp://*:5555")
+
+	// Socket to talk to workers
+	workers, _ := context.NewSocket(zmq.DEALER)
+	defer workers.Close()
+	workers.Bind("ipc://workers.ipc")
+
+	// connect work threads to client threads via a queue
+	zmq.Device(zmq.QUEUE, clients, workers)
+
 }
 
 func worker() {
-    context, _ := zmq.NewContext()
+	context, _ := zmq.NewContext()
 	defer context.Close()
-    
-    // Socket to talk to dispatcher
-    receiver, _ := context.NewSocket(zmq.REP)
-    defer receiver.Close()
-    receiver.Connect("ipc://workers.ipc")
-    
-    for true {
-       received, _ := receiver.Recv(0)
-       fmt.Printf("Received request [%s]\n", received)
-       
-       // Do some 'work'
-       time.Sleep(time.Second)
-       
-       // Send reply back to client
-       receiver.Send([]byte("World"), 0)
-    }
+
+	// Socket to talk to dispatcher
+	receiver, _ := context.NewSocket(zmq.REP)
+	defer receiver.Close()
+	receiver.Connect("ipc://workers.ipc")
+
+	for true {
+		received, _ := receiver.Recv(0)
+		fmt.Printf("Received request [%s]\n", received)
+
+		// Do some 'work'
+		time.Sleep(time.Second)
+
+		// Send reply back to client
+		receiver.Send([]byte("World"), 0)
+	}
 }

--- a/examples/Go/ppqueue.go
+++ b/examples/Go/ppqueue.go
@@ -6,150 +6,149 @@
 package main
 
 import (
-    "container/list"
-    "fmt"
-    "time"
-    zmq "github.com/alecthomas/gozmq"
+	"container/list"
+	"fmt"
+	zmq "github.com/alecthomas/gozmq"
+	"time"
 )
 
 const (
-    HEARTBEAT_LIVENESS = 3           //  3-5 is reasonable
-    HEARTBEAT_INTERVAL = time.Second //  time.Duration
+	HEARTBEAT_LIVENESS = 3           //  3-5 is reasonable
+	HEARTBEAT_INTERVAL = time.Second //  time.Duration
 
-    //  Paranoid Pirate Protocol constants
-    PPP_READY     = "\001"           //  Signals worker is ready
-    PPP_HEARTBEAT = "\002"           //  Signals worker heartbeat
+	//  Paranoid Pirate Protocol constants
+	PPP_READY     = "\001" //  Signals worker is ready
+	PPP_HEARTBEAT = "\002" //  Signals worker heartbeat
 )
 
 type Worker struct {
-    address []byte          //  Address of worker
-    expiry  time.Time       //  Expires at this time
+	address []byte    //  Address of worker
+	expiry  time.Time //  Expires at this time
 }
 
 func NewWorker(address []byte) *Worker {
-    return &Worker{
-        address: address,
-        expiry: time.Now().Add(HEARTBEAT_LIVENESS * HEARTBEAT_INTERVAL),
-    }
+	return &Worker{
+		address: address,
+		expiry:  time.Now().Add(HEARTBEAT_LIVENESS * HEARTBEAT_INTERVAL),
+	}
 }
 
 type WorkerQueue struct {
-    queue *list.List
+	queue *list.List
 }
 
 func NewWorkerQueue() *WorkerQueue {
-    return &WorkerQueue{
-        queue: list.New(),
-    }
+	return &WorkerQueue{
+		queue: list.New(),
+	}
 }
 
-func (workers *WorkerQueue) Len() int{
-    return workers.queue.Len()
+func (workers *WorkerQueue) Len() int {
+	return workers.queue.Len()
 }
 
-func (workers *WorkerQueue) Next() []byte{
-    elem := workers.queue.Back()
-    worker, _ := elem.Value.(*Worker)
-    workers.queue.Remove(elem)
-    return worker.address
+func (workers *WorkerQueue) Next() []byte {
+	elem := workers.queue.Back()
+	worker, _ := elem.Value.(*Worker)
+	workers.queue.Remove(elem)
+	return worker.address
 }
 
 func (workers *WorkerQueue) Ready(worker *Worker) {
-    for elem := workers.queue.Front(); elem != nil; elem = elem.Next() {
-        if w, _ := elem.Value.(*Worker); string(w.address) == string(worker.address) {
-            workers.queue.Remove(elem)
-            break
-        }
-    }
-    workers.queue.PushBack(worker)
+	for elem := workers.queue.Front(); elem != nil; elem = elem.Next() {
+		if w, _ := elem.Value.(*Worker); string(w.address) == string(worker.address) {
+			workers.queue.Remove(elem)
+			break
+		}
+	}
+	workers.queue.PushBack(worker)
 }
 
 func (workers *WorkerQueue) Purge() {
-    now := time.Now()
-    for elem := workers.queue.Front(); elem != nil; elem = workers.queue.Front() {
-        if w, _ := elem.Value.(*Worker); w.expiry.After(now) {
-            break
-        }
-        workers.queue.Remove(elem)
-    }
+	now := time.Now()
+	for elem := workers.queue.Front(); elem != nil; elem = workers.queue.Front() {
+		if w, _ := elem.Value.(*Worker); w.expiry.After(now) {
+			break
+		}
+		workers.queue.Remove(elem)
+	}
 }
 
 func main() {
-    context, _ := zmq.NewContext()
-    defer context.Close()
+	context, _ := zmq.NewContext()
+	defer context.Close()
 
-    frontend, _ := context.NewSocket(zmq.ROUTER)
-    defer frontend.Close()
-    frontend.Bind("tcp://*:5555")       //  For clients
+	frontend, _ := context.NewSocket(zmq.ROUTER)
+	defer frontend.Close()
+	frontend.Bind("tcp://*:5555") //  For clients
 
-    backend, _ := context.NewSocket(zmq.ROUTER)
-    defer backend.Close()
-    backend.Bind("tcp://*:5556")        //  For workers
+	backend, _ := context.NewSocket(zmq.ROUTER)
+	defer backend.Close()
+	backend.Bind("tcp://*:5556") //  For workers
 
-    workers := NewWorkerQueue()
-    heartbeatAt := time.Now().Add(HEARTBEAT_INTERVAL)
+	workers := NewWorkerQueue()
+	heartbeatAt := time.Now().Add(HEARTBEAT_INTERVAL)
 
-    for {
-        items := zmq.PollItems{
-            zmq.PollItem{Socket: backend, Events: zmq.POLLIN},
-            zmq.PollItem{Socket: frontend, Events: zmq.POLLIN},
-        }
+	for {
+		items := zmq.PollItems{
+			zmq.PollItem{Socket: backend, Events: zmq.POLLIN},
+			zmq.PollItem{Socket: frontend, Events: zmq.POLLIN},
+		}
 
-        //  Poll frontend only if we have available workers
-        if workers.Len() > 0 {
-            zmq.Poll(items, HEARTBEAT_INTERVAL.Nanoseconds()/1e3)
-        } else {
-            zmq.Poll(items[:1], HEARTBEAT_INTERVAL.Nanoseconds()/1e3)
-        }
+		//  Poll frontend only if we have available workers
+		if workers.Len() > 0 {
+			zmq.Poll(items, HEARTBEAT_INTERVAL.Nanoseconds()/1e3)
+		} else {
+			zmq.Poll(items[:1], HEARTBEAT_INTERVAL.Nanoseconds()/1e3)
+		}
 
-        //  Handle worker activity on backend
-        if items[0].REvents&zmq.POLLIN != 0 {
-            frames, err := backend.RecvMultipart(0)
-            if err != nil {
-                panic(err)      //  Interrupted
-            }
-            address := frames[0]
-            workers.Ready(NewWorker(address))
+		//  Handle worker activity on backend
+		if items[0].REvents&zmq.POLLIN != 0 {
+			frames, err := backend.RecvMultipart(0)
+			if err != nil {
+				panic(err) //  Interrupted
+			}
+			address := frames[0]
+			workers.Ready(NewWorker(address))
 
-            //  Validate control message, or return reply to client
-            if msg := frames[1:]; len(msg) == 1 {
-                switch status := string(msg[0]); status {
-                    case PPP_READY:
-                        fmt.Println("I: Worker ready")
-                    case PPP_HEARTBEAT:
-                        fmt.Println("I: Worker heartbeat")
-                    default:
-                        fmt.Println("E: Invalid message from worker: ", msg)
-                }
-            } else {
-                frontend.SendMultipart(msg, 0)
-            }
-        }
+			//  Validate control message, or return reply to client
+			if msg := frames[1:]; len(msg) == 1 {
+				switch status := string(msg[0]); status {
+				case PPP_READY:
+					fmt.Println("I: Worker ready")
+				case PPP_HEARTBEAT:
+					fmt.Println("I: Worker heartbeat")
+				default:
+					fmt.Println("E: Invalid message from worker: ", msg)
+				}
+			} else {
+				frontend.SendMultipart(msg, 0)
+			}
+		}
 
-        if items[1].REvents&zmq.POLLIN != 0 {
-            //  Now get next client request, route to next worker
-            frames, err := frontend.RecvMultipart(0)
-            if err != nil {
-                panic(err)
-            }
-            frames = append([][]byte{workers.Next()}, frames...)
-            backend.SendMultipart(frames, 0)
-        }
+		if items[1].REvents&zmq.POLLIN != 0 {
+			//  Now get next client request, route to next worker
+			frames, err := frontend.RecvMultipart(0)
+			if err != nil {
+				panic(err)
+			}
+			frames = append([][]byte{workers.Next()}, frames...)
+			backend.SendMultipart(frames, 0)
+		}
 
-        //  .split handle heartbeating
-        //  We handle heartbeating after any socket activity. First we send
-        //  heartbeats to any idle workers if it's time. Then we purge any
-        //  dead workers:
-        if heartbeatAt.Before(time.Now()) {
-            for elem := workers.queue.Front(); elem != nil; elem = elem.Next() {
-                w, _ := elem.Value.(*Worker)
-                msg := [][]byte{w.address, []byte(PPP_HEARTBEAT)}
-                backend.SendMultipart(msg, 0)
-            }
-            heartbeatAt = time.Now().Add(HEARTBEAT_INTERVAL)
-        }
+		//  .split handle heartbeating
+		//  We handle heartbeating after any socket activity. First we send
+		//  heartbeats to any idle workers if it's time. Then we purge any
+		//  dead workers:
+		if heartbeatAt.Before(time.Now()) {
+			for elem := workers.queue.Front(); elem != nil; elem = elem.Next() {
+				w, _ := elem.Value.(*Worker)
+				msg := [][]byte{w.address, []byte(PPP_HEARTBEAT)}
+				backend.SendMultipart(msg, 0)
+			}
+			heartbeatAt = time.Now().Add(HEARTBEAT_INTERVAL)
+		}
 
-        workers.Purge()
-    }
+		workers.Purge()
+	}
 }
-

--- a/examples/Go/ppworker.go
+++ b/examples/Go/ppworker.go
@@ -6,35 +6,35 @@
 package main
 
 import (
-    "fmt"
-    "math/rand"
-    "time"
-    zmq "github.com/alecthomas/gozmq"
+	"fmt"
+	zmq "github.com/alecthomas/gozmq"
+	"math/rand"
+	"time"
 )
 
 const (
-    HEARTBEAT_LIVENESS = 3              //  3-5 is reasonable
-    HEARTBEAT_INTERVAL = time.Second    //  time.Duration
+	HEARTBEAT_LIVENESS = 3           //  3-5 is reasonable
+	HEARTBEAT_INTERVAL = time.Second //  time.Duration
 
-    INTERVAL_INIT = time.Second         //  Initial reconnect
-    INTERVAL_MAX = 32 * time.Second     //  After exponential backoff
+	INTERVAL_INIT = time.Second      //  Initial reconnect
+	INTERVAL_MAX  = 32 * time.Second //  After exponential backoff
 
-    //  Paranoid Pirate Protocol constants
-    PPP_READY = "\001"                  //  Signals worker is ready
-    PPP_HEARTBEAT = "\002"              //  Signals worker heartbeat
+	//  Paranoid Pirate Protocol constants
+	PPP_READY     = "\001" //  Signals worker is ready
+	PPP_HEARTBEAT = "\002" //  Signals worker heartbeat
 )
 
 //  Helper function that returns a new configured socket
 //  connected to the Paranoid Pirate queue
 
-func WorkerSocket(context zmq.Context) zmq.Socket{
-    worker, _ := context.NewSocket(zmq.DEALER)
-    worker.Connect("tcp://localhost:5556")
+func WorkerSocket(context zmq.Context) zmq.Socket {
+	worker, _ := context.NewSocket(zmq.DEALER)
+	worker.Connect("tcp://localhost:5556")
 
-    //  Tell queue we're ready for work
-    fmt.Println("I: worker ready")
-    worker.Send([]byte(PPP_READY), 0)
-    return worker
+	//  Tell queue we're ready for work
+	fmt.Println("I: worker ready")
+	worker.Send([]byte(PPP_READY), 0)
+	return worker
 }
 
 //  .split main task
@@ -44,72 +44,72 @@ func WorkerSocket(context zmq.Context) zmq.Socket{
 //  died, and vice-versa:
 
 func main() {
-    src := rand.NewSource(time.Now().UnixNano())
-    random := rand.New(src)
+	src := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(src)
 
-    context, _ := zmq.NewContext()
-    defer context.Close()
+	context, _ := zmq.NewContext()
+	defer context.Close()
 
-    worker := WorkerSocket(context)
+	worker := WorkerSocket(context)
 
-    liveness := HEARTBEAT_LIVENESS
-    interval := INTERVAL_INIT
-    heartbeatAt := time.Now().Add(HEARTBEAT_INTERVAL)
-    cycles := 0
-    for {
-        items := zmq.PollItems{
-            zmq.PollItem{Socket: worker, Events: zmq.POLLIN},
-        }
+	liveness := HEARTBEAT_LIVENESS
+	interval := INTERVAL_INIT
+	heartbeatAt := time.Now().Add(HEARTBEAT_INTERVAL)
+	cycles := 0
+	for {
+		items := zmq.PollItems{
+			zmq.PollItem{Socket: worker, Events: zmq.POLLIN},
+		}
 
-        zmq.Poll(items, HEARTBEAT_INTERVAL.Nanoseconds()/1e3)
+		zmq.Poll(items, HEARTBEAT_INTERVAL.Nanoseconds()/1e3)
 
-        if items[0].REvents&zmq.POLLIN != 0 {
-            frames, err := worker.RecvMultipart(0)
-            if err != nil {
-                panic(err)
-            }
+		if items[0].REvents&zmq.POLLIN != 0 {
+			frames, err := worker.RecvMultipart(0)
+			if err != nil {
+				panic(err)
+			}
 
-            if len(frames) == 3 {
-                cycles ++
-                if cycles > 3 {
-                    switch r := random.Intn(5); r {
-                    case 0:
-                        fmt.Println("I: Simulating a crash")
-                        worker.Close()
-                        return
-                    case 1:
-                        fmt.Println("I: Simulating CPU overload")
-                        time.Sleep(3 * time.Second)
-                    }
-                }
-                fmt.Println("I: Normal reply")
-                worker.SendMultipart(frames, 0)
-                liveness = HEARTBEAT_LIVENESS
-                time.Sleep(1 * time.Second)
-            } else if len(frames) == 1 && string(frames[0]) == PPP_HEARTBEAT {
-                fmt.Println("I: Queue heartbeat")
-                liveness = HEARTBEAT_LIVENESS
-            } else {
-                fmt.Println("E: Invalid message")
-            }
-            interval = INTERVAL_INIT
-        } else if liveness --; liveness == 0 {
-                fmt.Println("W: Heartbeat failure, can't reach queue")
-                fmt.Printf("W: Reconnecting in %0.2fs...", interval)
-                time.Sleep(interval)
+			if len(frames) == 3 {
+				cycles++
+				if cycles > 3 {
+					switch r := random.Intn(5); r {
+					case 0:
+						fmt.Println("I: Simulating a crash")
+						worker.Close()
+						return
+					case 1:
+						fmt.Println("I: Simulating CPU overload")
+						time.Sleep(3 * time.Second)
+					}
+				}
+				fmt.Println("I: Normal reply")
+				worker.SendMultipart(frames, 0)
+				liveness = HEARTBEAT_LIVENESS
+				time.Sleep(1 * time.Second)
+			} else if len(frames) == 1 && string(frames[0]) == PPP_HEARTBEAT {
+				fmt.Println("I: Queue heartbeat")
+				liveness = HEARTBEAT_LIVENESS
+			} else {
+				fmt.Println("E: Invalid message")
+			}
+			interval = INTERVAL_INIT
+		} else if liveness--; liveness == 0 {
+			fmt.Println("W: Heartbeat failure, can't reach queue")
+			fmt.Printf("W: Reconnecting in %0.2fs...", interval)
+			time.Sleep(interval)
 
-                if interval < INTERVAL_MAX {
-                    interval *= 2
-                }
-                worker.Close()
-                worker = WorkerSocket(context)
-                liveness = HEARTBEAT_LIVENESS
-        }
+			if interval < INTERVAL_MAX {
+				interval *= 2
+			}
+			worker.Close()
+			worker = WorkerSocket(context)
+			liveness = HEARTBEAT_LIVENESS
+		}
 
-        if heartbeatAt.Before(time.Now()) {
-            heartbeatAt = time.Now().Add(HEARTBEAT_INTERVAL)
-            worker.Send([]byte(PPP_HEARTBEAT), 0)
-        }
-    }
+		if heartbeatAt.Before(time.Now()) {
+			heartbeatAt = time.Now().Add(HEARTBEAT_INTERVAL)
+			worker.Send([]byte(PPP_HEARTBEAT), 0)
+		}
+	}
 
 }

--- a/examples/Go/rrbroker.go
+++ b/examples/Go/rrbroker.go
@@ -6,37 +6,37 @@
 package main
 
 import (
-    zmq "github.com/alecthomas/gozmq"
+	zmq "github.com/alecthomas/gozmq"
 )
 
 func main() {
-    context, _ := zmq.NewContext()
+	context, _ := zmq.NewContext()
 	defer context.Close()
-    
-    frontend, _ := context.NewSocket(zmq.ROUTER)
-    backend, _ := context.NewSocket(zmq.DEALER)
-    defer frontend.Close()
-    defer backend.Close()
-    frontend.Bind("tcp://*:5559")
-    backend.Bind("tcp://*:5560")
-    
-    // Initialize poll set
-    toPoll := zmq.PollItems{
-        zmq.PollItem{Socket: frontend, zmq.Events: zmq.POLLIN},
-        zmq.PollItem{Socket: backend, zmq.Events: zmq.POLLIN},
-    }
-    
-    for {
-        _, _ = zmq.Poll(toPoll, -1)
-        
-        switch {
-            case toPoll[0].REvents&zmq.POLLIN != 0:
-                message, _ := toPoll[0].Socket.Recv(0)
-                backend.Send(message, 0)
-                
-            case toPoll[1].REvents&zmq.POLLIN != 0:
-                message, _ := toPoll[1].Socket.Recv(0)
-                frontend.Send(message, 0)
-        }
-    }
+
+	frontend, _ := context.NewSocket(zmq.ROUTER)
+	backend, _ := context.NewSocket(zmq.DEALER)
+	defer frontend.Close()
+	defer backend.Close()
+	frontend.Bind("tcp://*:5559")
+	backend.Bind("tcp://*:5560")
+
+	// Initialize poll set
+	toPoll := zmq.PollItems{
+		zmq.PollItem{Socket: frontend, zmq.Events: zmq.POLLIN},
+		zmq.PollItem{Socket: backend, zmq.Events: zmq.POLLIN},
+	}
+
+	for {
+		_, _ = zmq.Poll(toPoll, -1)
+
+		switch {
+		case toPoll[0].REvents&zmq.POLLIN != 0:
+			message, _ := toPoll[0].Socket.Recv(0)
+			backend.Send(message, 0)
+
+		case toPoll[1].REvents&zmq.POLLIN != 0:
+			message, _ := toPoll[1].Socket.Recv(0)
+			frontend.Send(message, 0)
+		}
+	}
 }

--- a/examples/Go/rrclient.go
+++ b/examples/Go/rrclient.go
@@ -8,23 +8,22 @@
 package main
 
 import (
-    "fmt"
-    zmq "github.com/alecthomas/gozmq"
+	"fmt"
+	zmq "github.com/alecthomas/gozmq"
 )
 
 func main() {
-    context, _ := zmq.NewContext()
+	context, _ := zmq.NewContext()
 	defer context.Close()
-    
-    // Socket to talk to clients
-    requester, _ := context.NewSocket(zmq.REQ)
-    defer requester.Close()
-    requester.Connect("tcp://localhost:5559")
-    
-    for i := 0;i < 10;i++{
-        requester.Send([]byte("Hello"), 0)
-        reply, _ := requester.Recv(0)
-        fmt.Printf("Received reply %d [%s]\n", i, reply)
-    }
-}
 
+	// Socket to talk to clients
+	requester, _ := context.NewSocket(zmq.REQ)
+	defer requester.Close()
+	requester.Connect("tcp://localhost:5559")
+
+	for i := 0; i < 10; i++ {
+		requester.Send([]byte("Hello"), 0)
+		reply, _ := requester.Recv(0)
+		fmt.Printf("Received reply %d [%s]\n", i, reply)
+	}
+}

--- a/examples/Go/rrworker.go
+++ b/examples/Go/rrworker.go
@@ -8,29 +8,29 @@
 package main
 
 import (
-    "fmt"
-    zmq "github.com/alecthomas/gozmq"
-    "time"
+	"fmt"
+	zmq "github.com/alecthomas/gozmq"
+	"time"
 )
 
 func main() {
-    context, _ := zmq.NewContext()
+	context, _ := zmq.NewContext()
 	defer context.Close()
-    
-    // Socket to talk to clients
-    responder, _ := context.NewSocket(zmq.REP)
-    defer responder.Close()
-    responder.Connect("tcp://localhost:5560")
-    
-    for {
-        //  Wait for next request from client
-        request, _ := responder.Recv(0)
-        fmt.Printf("Received request: [%s]\n", request)
-        
-        // Do some 'work'
-        time.Sleep(1 * time.Second)
-        
-        // Send reply back to client
-        responder.Send([]byte("World"), 0)
-    }
+
+	// Socket to talk to clients
+	responder, _ := context.NewSocket(zmq.REP)
+	defer responder.Close()
+	responder.Connect("tcp://localhost:5560")
+
+	for {
+		//  Wait for next request from client
+		request, _ := responder.Recv(0)
+		fmt.Printf("Received request: [%s]\n", request)
+
+		// Do some 'work'
+		time.Sleep(1 * time.Second)
+
+		// Send reply back to client
+		responder.Send([]byte("World"), 0)
+	}
 }

--- a/examples/Go/spqueue.go
+++ b/examples/Go/spqueue.go
@@ -8,65 +8,65 @@
 package main
 
 import (
-    zmq "github.com/alecthomas/gozmq"
+	zmq "github.com/alecthomas/gozmq"
 )
 
 const LRU_READY = "\001"
 
 func main() {
-    context, _ := zmq.NewContext()
-    defer context.Close()
+	context, _ := zmq.NewContext()
+	defer context.Close()
 
-    frontend, _ := context.NewSocket(zmq.ROUTER)
-    defer frontend.Close()
-    frontend.Bind("tcp://*:5555")   //  For clients
+	frontend, _ := context.NewSocket(zmq.ROUTER)
+	defer frontend.Close()
+	frontend.Bind("tcp://*:5555") //  For clients
 
-    backend, _ := context.NewSocket(zmq.ROUTER)
-    defer backend.Close()
-    backend.Bind("tcp://*:5556")    //  For workers
+	backend, _ := context.NewSocket(zmq.ROUTER)
+	defer backend.Close()
+	backend.Bind("tcp://*:5556") //  For workers
 
-    //  Queue of available workers
-    workers := make([][]byte, 0, 0)
+	//  Queue of available workers
+	workers := make([][]byte, 0, 0)
 
-    for {
-        items := zmq.PollItems{
-            zmq.PollItem{Socket: backend, Events: zmq.POLLIN},
-            zmq.PollItem{Socket: frontend, Events: zmq.POLLIN},
-        }
+	for {
+		items := zmq.PollItems{
+			zmq.PollItem{Socket: backend, Events: zmq.POLLIN},
+			zmq.PollItem{Socket: frontend, Events: zmq.POLLIN},
+		}
 
-        //  Poll frontend only if we have available workers
-        if len(workers) > 0 {
-            zmq.Poll(items, -1)
-        } else {
-            zmq.Poll(items[:1], -1)
-        }
+		//  Poll frontend only if we have available workers
+		if len(workers) > 0 {
+			zmq.Poll(items, -1)
+		} else {
+			zmq.Poll(items[:1], -1)
+		}
 
-        //  Handle worker activity on backend
-        if items[0].REvents&zmq.POLLIN != 0 {
-            //  Use worker identity for load-balancing
-            msg, err := backend.RecvMultipart(0)
-            if err != nil {
-                panic(err)      //  Interrupted
-            }
-            address := msg[0]
-            workers = append(workers, address)
+		//  Handle worker activity on backend
+		if items[0].REvents&zmq.POLLIN != 0 {
+			//  Use worker identity for load-balancing
+			msg, err := backend.RecvMultipart(0)
+			if err != nil {
+				panic(err) //  Interrupted
+			}
+			address := msg[0]
+			workers = append(workers, address)
 
-            //  Forward message to client if it's not a READY
-            if reply := msg[2:]; string(reply[0]) != LRU_READY {
-                frontend.SendMultipart(reply, 0)
-            }
-        }
+			//  Forward message to client if it's not a READY
+			if reply := msg[2:]; string(reply[0]) != LRU_READY {
+				frontend.SendMultipart(reply, 0)
+			}
+		}
 
-        if items[1].REvents&zmq.POLLIN != 0 {
-            //  Get client request, route to first available worker
-            msg, err := frontend.RecvMultipart(0)
-            if err != nil {
-                panic(err)      //  Interrupted
-            }
-            last := workers[len(workers)-1]
-            workers = workers[:len(workers)-1]
-            request := append([][]byte{last, nil}, msg...)
-            backend.SendMultipart(request, 0)
-        }
-    }
+		if items[1].REvents&zmq.POLLIN != 0 {
+			//  Get client request, route to first available worker
+			msg, err := frontend.RecvMultipart(0)
+			if err != nil {
+				panic(err) //  Interrupted
+			}
+			last := workers[len(workers)-1]
+			workers = workers[:len(workers)-1]
+			request := append([][]byte{last, nil}, msg...)
+			backend.SendMultipart(request, 0)
+		}
+	}
 }

--- a/examples/Go/spworker.go
+++ b/examples/Go/spworker.go
@@ -8,51 +8,51 @@
 package main
 
 import (
-    "fmt"
-    "math/rand"
-    "time"
-    zmq "github.com/alecthomas/gozmq"
+	"fmt"
+	zmq "github.com/alecthomas/gozmq"
+	"math/rand"
+	"time"
 )
 
 const LRU_READY = "\001"
 
 func main() {
-    context, _ := zmq.NewContext()
-    defer context.Close()
+	context, _ := zmq.NewContext()
+	defer context.Close()
 
-    worker, _ := context.NewSocket(zmq.REQ)
-    defer worker.Close()
+	worker, _ := context.NewSocket(zmq.REQ)
+	defer worker.Close()
 
-    //  Set random identity to make tracing easier
-    src := rand.NewSource(time.Now().UnixNano())
-    random := rand.New(src)
-    identity := fmt.Sprintf("%04X-%04X", random.Intn(0x10000), random.Intn(0x10000))
-    worker.SetSockOptString(zmq.IDENTITY, identity)
-    worker.Connect("tcp://localhost:5556")
+	//  Set random identity to make tracing easier
+	src := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(src)
+	identity := fmt.Sprintf("%04X-%04X", random.Intn(0x10000), random.Intn(0x10000))
+	worker.SetSockOptString(zmq.IDENTITY, identity)
+	worker.Connect("tcp://localhost:5556")
 
-    //  Tell broker we're ready for work
-    fmt.Printf("I: (%s) worker ready\n", identity)
-    worker.Send([]byte(LRU_READY), 0)
+	//  Tell broker we're ready for work
+	fmt.Printf("I: (%s) worker ready\n", identity)
+	worker.Send([]byte(LRU_READY), 0)
 
-    for cycles := 1;; cycles ++ {
-        msg, err := worker.RecvMultipart(0)
-        if err != nil {
-            panic(err)      //  Interrupted
-        }
+	for cycles := 1; ; cycles++ {
+		msg, err := worker.RecvMultipart(0)
+		if err != nil {
+			panic(err) //  Interrupted
+		}
 
-        if cycles > 3 {
-            switch r := random.Intn(5); r {
-            case 0:
-                fmt.Printf("I: (%s) simulating a crash\n", identity)
-                return
-            case 1:
-                fmt.Printf("I: (%s) simulating CPU overload\n", identity)
-                time.Sleep(3 * time.Second)
-            }
-        }
+		if cycles > 3 {
+			switch r := random.Intn(5); r {
+			case 0:
+				fmt.Printf("I: (%s) simulating a crash\n", identity)
+				return
+			case 1:
+				fmt.Printf("I: (%s) simulating CPU overload\n", identity)
+				time.Sleep(3 * time.Second)
+			}
+		}
 
-        fmt.Printf("I: (%s) normal reply\n", identity)
-        time.Sleep(1 * time.Second)     //  Do some heavy work
-        worker.SendMultipart(msg, 0)
-    }
+		fmt.Printf("I: (%s) normal reply\n", identity)
+		time.Sleep(1 * time.Second) //  Do some heavy work
+		worker.SendMultipart(msg, 0)
+	}
 }

--- a/examples/Go/syncpub.go
+++ b/examples/Go/syncpub.go
@@ -6,34 +6,34 @@
 package main
 
 import (
-    zmq "github.com/alecthomas/gozmq"
+	zmq "github.com/alecthomas/gozmq"
 )
 
 var subsExpected = 10
 
 func main() {
-    context, _ := zmq.NewContext()
+	context, _ := zmq.NewContext()
 	defer context.Close()
-    
-    // Socket to talk to clients
-    publisher, _ := context.NewSocket(zmq.PUB)
-    defer publisher.Close()
-    publisher.Bind("tcp://*:5561")
-    
-    // Socket to receive signals
-    syncservice, _ := context.NewSocket(zmq.REP)
-    defer syncservice.Close()
-    syncservice.Bind("tcp://*:5562")
-    
-    // Get synchronization from subscribers
-    for i := 0;i < subsExpected;i = i + 1 {
-        syncservice.Recv(0)
-        syncservice.Send([]byte(""), 0)
-    }
-    
-    for update_nbr := 0;update_nbr < 1000000;update_nbr = update_nbr + 1 {
-        publisher.Send([]byte("Rhubarb"), 0)
-    }
-    
-    publisher.Send([]byte("END"), 0)
+
+	// Socket to talk to clients
+	publisher, _ := context.NewSocket(zmq.PUB)
+	defer publisher.Close()
+	publisher.Bind("tcp://*:5561")
+
+	// Socket to receive signals
+	syncservice, _ := context.NewSocket(zmq.REP)
+	defer syncservice.Close()
+	syncservice.Bind("tcp://*:5562")
+
+	// Get synchronization from subscribers
+	for i := 0; i < subsExpected; i = i + 1 {
+		syncservice.Recv(0)
+		syncservice.Send([]byte(""), 0)
+	}
+
+	for update_nbr := 0; update_nbr < 1000000; update_nbr = update_nbr + 1 {
+		publisher.Send([]byte("Rhubarb"), 0)
+	}
+
+	publisher.Send([]byte("END"), 0)
 }

--- a/examples/Go/version.go
+++ b/examples/Go/version.go
@@ -7,11 +7,11 @@
 package main
 
 import (
-  "fmt"
-  zmq "github.com/alecthomas/gozmq"
+	"fmt"
+	zmq "github.com/alecthomas/gozmq"
 )
 
 func main() {
-  major, minor, patch := zmq.Version()
-  fmt.Printf("Current 0MQ version is %d.%d.%d\n", major, minor, patch)
+	major, minor, patch := zmq.Version()
+	fmt.Printf("Current 0MQ version is %d.%d.%d\n", major, minor, patch)
 }

--- a/examples/Go/wuproxy.go
+++ b/examples/Go/wuproxy.go
@@ -6,29 +6,29 @@
 package main
 
 import (
-    zmq "github.com/alecthomas/gozmq"
+	zmq "github.com/alecthomas/gozmq"
 )
 
 func main() {
-    context, _ := zmq.NewContext()
+	context, _ := zmq.NewContext()
 	defer context.Close()
-    
-    // This is where the weather server sits
-    frontend, _ := context.NewSocket(zmq.SUB)
-    defer frontend.Close()
-    frontend.Connect("tcp://localhost:5556")
-    
-    // This is our public endpoint for subscribers
-    backend, _ := context.NewSocket(zmq.PUB)
-    defer backend.Close()
-    backend.Bind("tcp://*:8100")
-    
-    // Subscribe on everything
-    frontend.SetSockOptString(zmq.SUBSCRIBE, "")
-    
-    // Shunt messages out to our own subscribers
-    for {
-        message, _ := frontend.Recv(0)
-        backend.Send(message, 0)
-    }
+
+	// This is where the weather server sits
+	frontend, _ := context.NewSocket(zmq.SUB)
+	defer frontend.Close()
+	frontend.Connect("tcp://localhost:5556")
+
+	// This is our public endpoint for subscribers
+	backend, _ := context.NewSocket(zmq.PUB)
+	defer backend.Close()
+	backend.Bind("tcp://*:8100")
+
+	// Subscribe on everything
+	frontend.SetSockOptString(zmq.SUBSCRIBE, "")
+
+	// Shunt messages out to our own subscribers
+	for {
+		message, _ := frontend.Recv(0)
+		backend.Send(message, 0)
+	}
 }

--- a/examples/Go/zhelpers.go
+++ b/examples/Go/zhelpers.go
@@ -5,53 +5,53 @@
 package main
 
 import (
-    "container/list"
-    "fmt"
-    "reflect"
+	"container/list"
+	"fmt"
+	"reflect"
 )
 
 //  Golang implementation of zlist in C
 type ZList struct {
-    list.List
+	list.List
 }
 
 func NewList() *ZList {
-    return new(ZList)
+	return new(ZList)
 }
 
 func (self *ZList) Delete(value interface{}) {
-    for elem := self.Front(); elem != nil; elem = elem.Next() {
-        if reflect.DeepEqual(elem.Value, value) {
-            self.Remove(elem)
-            break
-        }
-    }
+	for elem := self.Front(); elem != nil; elem = elem.Next() {
+		if reflect.DeepEqual(elem.Value, value) {
+			self.Remove(elem)
+			break
+		}
+	}
 }
 
 func (self *ZList) Pop() *list.Element {
-    if self.Len() == 0 {
-        return nil
-    }
-    elem := self.Front()
-    self.Remove(elem)
-    return elem
+	if self.Len() == 0 {
+		return nil
+	}
+	elem := self.Front()
+	self.Remove(elem)
+	return elem
 }
 
 //  Print messages neatly
 func Dump(msg [][]byte) {
-    for _, part := range msg {
-        isText := true
-        fmt.Printf("[%03d] ", len(part))
-        for _, char := range part {
-            if char < 32 || char > 127 {
-                isText = false
-                break
-            }
-        }
-        if isText {
-            fmt.Printf("%s\n", part)
-        } else {
-            fmt.Printf("%X\n", part)
-        }
-    }
+	for _, part := range msg {
+		isText := true
+		fmt.Printf("[%03d] ", len(part))
+		for _, char := range part {
+			if char < 32 || char > 127 {
+				isText = false
+				break
+			}
+		}
+		if isText {
+			fmt.Printf("%s\n", part)
+		} else {
+			fmt.Printf("%X\n", part)
+		}
+	}
 }


### PR DESCRIPTION
This is done by running `go fmt` in the examples/Go directory.  The result is a standardized Go code format that makes it a bit easier to read and much easier to process with static analysis and refactoring tools.
