### PR TITLE
Update Go examples to build like the others.

### DIFF
--- a/examples/Go/README
+++ b/examples/Go/README
@@ -1,11 +1,6 @@
-Examples in Go 
+Examples in Go
+
+Use 'build all' to build all examples
+Use 'build hwserver' to build just hwserver (or any example)
+
 See LICENSE in examples directory
-
-
-To run the examples:
-
-  go run hwserver.go  # etc
-
-Or multiple files in some cases:
-
-  go run mdp.go zhelpers.go mdbroker.go [-v]  # etc

--- a/examples/Go/build
+++ b/examples/Go/build
@@ -1,0 +1,22 @@
+#! /bin/sh
+#
+#   Examples build helper
+#   Syntax: build all | clean
+#
+if [ /$1/ = /all/ ]; then
+    echo "Building Go examples..."
+    for MAIN in `egrep -l "^func main\(" *.go`; do
+        echo "$MAIN"
+        go build $MAIN `egrep -L "^func main\(" *.go`
+    done
+elif [ /$1/ = /clean/ ]; then
+    echo "Cleaning Go examples directory..."
+    for MAIN in `egrep -l "^func main\(" *.go`; do
+        rm -f `basename $MAIN .go`
+    done
+elif [ -f $1.go ]; then
+    echo "$1"
+    go build $1.go `egrep -L "^func main\(" *.go`
+else
+    echo "syntax: build all | clean"
+fi

--- a/examples/Go/mdcliapi.go
+++ b/examples/Go/mdcliapi.go
@@ -75,7 +75,7 @@ func (self *mdClient) Send(service []byte, request [][]byte) (reply [][]byte) {
 			zmq.PollItem{Socket: self.client, Events: zmq.POLLIN},
 		}
 
-		_, err := zmq.Poll(items, self.timeout.Nanoseconds()/1e3)
+		_, err := zmq.Poll(items, self.timeout)
 		if err != nil {
 			panic(err) //  Interrupted
 		}

--- a/examples/Go/mdwrkapi.go
+++ b/examples/Go/mdwrkapi.go
@@ -12,10 +12,6 @@ import (
 	"time"
 )
 
-const (
-	HEARTBEAT_LIVENESS = 3 //  3-5 is reasonable
-)
-
 type Worker interface {
 	Close()
 	Recv([][]byte) [][]byte
@@ -109,7 +105,7 @@ func (self *mdWorker) Recv(reply [][]byte) (msg [][]byte) {
 			zmq.PollItem{Socket: self.worker, Events: zmq.POLLIN},
 		}
 
-		_, err := zmq.Poll(items, self.heartbeat.Nanoseconds()/1e3)
+		_, err := zmq.Poll(items, self.heartbeat)
 		if err != nil {
 			panic(err) //  Interrupted
 		}

--- a/examples/Go/ppworker.go
+++ b/examples/Go/ppworker.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	HEARTBEAT_LIVENESS = 3           //  3-5 is reasonable
 	HEARTBEAT_INTERVAL = time.Second //  time.Duration
 
 	INTERVAL_INIT = time.Second      //  Initial reconnect
@@ -61,7 +60,7 @@ func main() {
 			zmq.PollItem{Socket: worker, Events: zmq.POLLIN},
 		}
 
-		zmq.Poll(items, HEARTBEAT_INTERVAL.Nanoseconds()/1e3)
+		zmq.Poll(items, HEARTBEAT_INTERVAL)
 
 		if items[0].REvents&zmq.POLLIN != 0 {
 			frames, err := worker.RecvMultipart(0)

--- a/examples/Go/zhelpers.go
+++ b/examples/Go/zhelpers.go
@@ -10,6 +10,10 @@ import (
 	"reflect"
 )
 
+const (
+	HEARTBEAT_LIVENESS = 3 //  3-5 is reasonable
+)
+
 //  Golang implementation of zlist in C
 type ZList struct {
 	list.List


### PR DESCRIPTION
The gozmq package API was updated in a way that was necessarily backwards incompatible: Poll must receive a time.Duration instead of an int64.  This commit updates the examples to use the new API.

Other example directories have build scripts and require no spelunking through code and/or build errors to get things working.  This commit also updates the Go examples to build so simply.
