### PR TITLE
Update Go examples for new gozmq API.

### DIFF
--- a/examples/Go/identity.go
+++ b/examples/Go/identity.go
@@ -10,7 +10,7 @@ import (
 	zmq "github.com/alecthomas/gozmq"
 )
 
-func dump(sink zmq.Socket) {
+func dump(sink *zmq.Socket) {
 	parts, err := sink.RecvMultipart(0)
 	if err != nil {
 		fmt.Println(err)

--- a/examples/Go/lbbroker.go
+++ b/examples/Go/lbbroker.go
@@ -26,7 +26,7 @@ func randomString() string {
 	return strings.Join(target, "")
 }
 
-func set_id(socket zmq.Socket) {
+func set_id(socket *zmq.Socket) {
 	socket.SetSockOptString(zmq.IDENTITY, randomString())
 }
 

--- a/examples/Go/mdbroker.go
+++ b/examples/Go/mdbroker.go
@@ -44,10 +44,10 @@ type mdService struct {
 }
 
 type mdBroker struct {
-	context     zmq.Context           //  Context
+	context     *zmq.Context          //  Context
 	heartbeatAt time.Time             //  When to send HEARTBEAT
 	services    map[string]*mdService //  Known services
-	socket      zmq.Socket            //  Socket for clients & workers
+	socket      *zmq.Socket           //  Socket for clients & workers
 	waiting     *ZList                //  Idle workers
 	workers     map[string]*mdbWorker //  Known workers
 	verbose     bool                  //  Print activity to stdout

--- a/examples/Go/mdcliapi.go
+++ b/examples/Go/mdcliapi.go
@@ -19,8 +19,8 @@ type Client interface {
 
 type mdClient struct {
 	broker  string
-	client  zmq.Socket
-	context zmq.Context
+	client  *zmq.Socket
+	context *zmq.Context
 	retries int
 	timeout time.Duration
 	verbose bool

--- a/examples/Go/mdwrkapi.go
+++ b/examples/Go/mdwrkapi.go
@@ -19,10 +19,10 @@ type Worker interface {
 
 type mdWorker struct {
 	broker  string
-	context zmq.Context
+	context *zmq.Context
 	service string
 	verbose bool
-	worker  zmq.Socket
+	worker  *zmq.Socket
 
 	heartbeat   time.Duration
 	heartbeatAt time.Time

--- a/examples/Go/ppworker.go
+++ b/examples/Go/ppworker.go
@@ -26,7 +26,7 @@ const (
 //  Helper function that returns a new configured socket
 //  connected to the Paranoid Pirate queue
 
-func WorkerSocket(context zmq.Context) zmq.Socket {
+func WorkerSocket(context *zmq.Context) *zmq.Socket {
 	worker, _ := context.NewSocket(zmq.DEALER)
 	worker.Connect("tcp://localhost:5556")
 


### PR DESCRIPTION
These changes were made entirely by the `gozmqfix` command that is now included in the gozmq repo.
