### PR TITLE
Fixed C++ example syntax error

### DIFF
--- a/examples/C++/hwserver.cpp
+++ b/examples/C++/hwserver.cpp
@@ -28,7 +28,7 @@ int main () {
         //  Do some 'work'
 #ifndef _WIN32
     	sleep(1);
-else
+#else
 	Sleep (1);
 #endif
 


### PR DESCRIPTION
Fixed `./build all` error:

```
Building C++ examples...
hwclient.cpp
hwserver.cpp
hwserver.cpp: In function ‘int main()’:
hwserver.cpp:31:1: error: ‘else’ without a previous ‘if’
hwserver.cpp:32:10: error: ‘Sleep’ was not declared in this scope
```
