### PR TITLE
Update Go examples to use socket option methods.

### DIFF
--- a/examples/Go/asyncsrv.go
+++ b/examples/Go/asyncsrv.go
@@ -41,7 +41,7 @@ func client_task() {
 	identity := "Client-" + randomString()
 
 	client, _ := context.NewSocket(zmq.DEALER)
-	client.SetSockOptString(zmq.IDENTITY, identity)
+	client.SetIdentity(identity)
 	client.Connect("ipc://frontend.ipc")
 	defer client.Close()
 

--- a/examples/Go/identity.go
+++ b/examples/Go/identity.go
@@ -62,7 +62,7 @@ func main() {
 		print(err)
 	}
 	defer identified.Close()
-	identified.SetSockOptString(zmq.IDENTITY, "PEER2")
+	identified.SetIdentity("PEER2")
 	identified.Connect("inproc://example")
 	identified.Send([]byte("ROUTER socket uses REQ's socket identity"), zmq.NOBLOCK)
 

--- a/examples/Go/lbbroker.go
+++ b/examples/Go/lbbroker.go
@@ -27,7 +27,7 @@ func randomString() string {
 }
 
 func set_id(socket *zmq.Socket) {
-	socket.SetSockOptString(zmq.IDENTITY, randomString())
+	socket.SetIdentity(randomString())
 }
 
 func client_task() {

--- a/examples/Go/lpclient.go
+++ b/examples/Go/lpclient.go
@@ -63,13 +63,13 @@ func main() {
 				}
 			} else if retriesLeft--; retriesLeft == 0 {
 				fmt.Println("E: Server seems to be offline, abandoning")
-				client.SetSockOptInt(zmq.LINGER, 0)
+				client.SetLinger(0)
 				client.Close()
 				break
 			} else {
 				fmt.Println("W: No response from server, retrying...")
 				//  Old socket is confused; close it and open a new one
-				client.SetSockOptInt(zmq.LINGER, 0)
+				client.SetLinger(0)
 				client.Close()
 				client, _ = context.NewSocket(zmq.REQ)
 				client.Connect(SERVER_ENDPOINT)

--- a/examples/Go/mdbroker.go
+++ b/examples/Go/mdbroker.go
@@ -56,7 +56,7 @@ type mdBroker struct {
 func NewBroker(endpoint string, verbose bool) Broker {
 	context, _ := zmq.NewContext()
 	socket, _ := context.NewSocket(zmq.ROUTER)
-	socket.SetSockOptInt(zmq.LINGER, 0)
+	socket.SetLinger(0)
 	socket.Bind(endpoint)
 	log.Printf("I: MDP broker/0.1.1 is active at %s\n", endpoint)
 	return &mdBroker{

--- a/examples/Go/mdcliapi.go
+++ b/examples/Go/mdcliapi.go
@@ -45,7 +45,7 @@ func (self *mdClient) reconnect() {
 	}
 
 	self.client, _ = self.context.NewSocket(zmq.REQ)
-	self.client.SetSockOptInt(zmq.LINGER, 0)
+	self.client.SetLinger(0)
 	self.client.Connect(self.broker)
 	if self.verbose {
 		log.Printf("I: connecting to broker at %s...\n", self.broker)

--- a/examples/Go/mdwrkapi.go
+++ b/examples/Go/mdwrkapi.go
@@ -53,7 +53,7 @@ func (self *mdWorker) reconnectToBroker() {
 		self.worker.Close()
 	}
 	self.worker, _ = self.context.NewSocket(zmq.DEALER)
-	self.worker.SetSockOptInt(zmq.LINGER, 0)
+	self.worker.SetLinger(0)
 	self.worker.Connect(self.broker)
 	if self.verbose {
 		log.Printf("I: connecting to broker at %s...\n", self.broker)

--- a/examples/Go/mspoller.go
+++ b/examples/Go/mspoller.go
@@ -23,7 +23,7 @@ func main() {
 	subscriber, _ := context.NewSocket(zmq.SUB)
 	defer subscriber.Close()
 	subscriber.Connect("tcp://localhost:5556")
-	subscriber.SetSockOptString(zmq.SUBSCRIBE, "10001")
+	subscriber.SetSubscribe("10001")
 
 	pi := zmq.PollItems{
 		zmq.PollItem{Socket: receiver, zmq.Events: zmq.POLLIN},

--- a/examples/Go/msreader.go
+++ b/examples/Go/msreader.go
@@ -24,7 +24,7 @@ func main() {
 	subscriber, _ := context.NewSocket(zmq.SUB)
 	defer subscriber.Close()
 	subscriber.Connect("tcp://localhost:5556")
-	subscriber.SetSockOptString(zmq.SUBSCRIBE, "10001")
+	subscriber.SetSubscribe("10001")
 
 	//  Process messages from both sockets
 	//  We prioritize traffic from the task ventilator

--- a/examples/Go/psenvsub.go
+++ b/examples/Go/psenvsub.go
@@ -15,7 +15,7 @@ func main() {
 	subscriber, _ := context.NewSocket(zmq.SUB)
 	defer subscriber.Close()
 	subscriber.Connect("tcp://localhost:5563")
-	subscriber.SetSockOptString(zmq.SUBSCRIBE, "B")
+	subscriber.SetSubscribe("B")
 
 	for {
 		address, _ := subscriber.Recv(0)

--- a/examples/Go/rtdealer.go
+++ b/examples/Go/rtdealer.go
@@ -28,7 +28,7 @@ func worker_task() {
 
 	worker, _ := context.NewSocket(zmq.DEALER)
 	defer worker.Close()
-	worker.SetSockOptString(zmq.IDENTITY, randomString())
+	worker.SetIdentity(randomString())
 	worker.Connect("tcp://localhost:5671")
 
 	total := 0
@@ -40,7 +40,7 @@ func worker_task() {
 		parts, _ := worker.RecvMultipart(0)
 		workload := parts[1]
 		if string(workload) == "Fired!" {
-			id, _ := worker.GetSockOptString(zmq.IDENTITY)
+			id, _ := worker.Identity()
 			fmt.Printf("Completed: %d tasks (%s)\n", total, id)
 			break
 		}

--- a/examples/Go/rtreq.go
+++ b/examples/Go/rtreq.go
@@ -28,7 +28,7 @@ func workerTask() {
 	defer context.Close()
 
 	worker, _ := context.NewSocket(zmq.REQ)
-	worker.SetSockOptString(zmq.IDENTITY, randomString())
+	worker.SetIdentity(randomString())
 
 	worker.Connect("tcp://localhost:5671")
 	defer worker.Close()
@@ -41,7 +41,7 @@ func workerTask() {
 		}
 		workload, _ := worker.Recv(0)
 		if string(workload) == "Fired!" {
-			id, _ := worker.GetSockOptString(zmq.IDENTITY)
+			id, _ := worker.Identity()
 			fmt.Printf("Completed: %d tasks (%s)\n", total, id)
 			break
 		}

--- a/examples/Go/spworker.go
+++ b/examples/Go/spworker.go
@@ -27,7 +27,7 @@ func main() {
 	src := rand.NewSource(time.Now().UnixNano())
 	random := rand.New(src)
 	identity := fmt.Sprintf("%04X-%04X", random.Intn(0x10000), random.Intn(0x10000))
-	worker.SetSockOptString(zmq.IDENTITY, identity)
+	worker.SetIdentity(identity)
 	worker.Connect("tcp://localhost:5556")
 
 	//  Tell broker we're ready for work

--- a/examples/Go/syncsub.go
+++ b/examples/Go/syncsub.go
@@ -18,7 +18,7 @@ func main() {
 	subscriber, _ := context.NewSocket(zmq.SUB)
 	defer subscriber.Close()
 	subscriber.Connect("tcp://localhost:5561")
-	subscriber.SetSockOptString(zmq.SUBSCRIBE, "")
+	subscriber.SetSubscribe("")
 
 	//  0MQ is so fast, we need to wait a while...
 	time.Sleep(time.Second)

--- a/examples/Go/taskwork2.go
+++ b/examples/Go/taskwork2.go
@@ -33,7 +33,7 @@ func main() {
 	controller, _ := context.NewSocket(zmq.SUB)
 	defer controller.Close()
 	controller.Connect("tcp://localhost:5559")
-	controller.SetSockOptString(zmq.SUBSCRIBE, "")
+	controller.SetSubscribe("")
 
 	items := zmq.PollItems{
 		zmq.PollItem{Socket: receiver, zmq.Events: zmq.POLLIN},

--- a/examples/Go/wuclient.go
+++ b/examples/Go/wuclient.go
@@ -32,7 +32,7 @@ func main() {
 
 	//  Subscribe to just one zipcode (whitefish MT 59937) 
 	fmt.Printf("Collecting updates from weather server for %s…\n", filter)
-	socket.SetSockOptString(zmq.SUBSCRIBE, filter)
+	socket.SetSubscribe(filter)
 	socket.Connect("tcp://localhost:5556")
 
 	for i := 0; i < 101; i++ {

--- a/examples/Go/wuproxy.go
+++ b/examples/Go/wuproxy.go
@@ -24,7 +24,7 @@ func main() {
 	backend.Bind("tcp://*:8100")
 
 	// Subscribe on everything
-	frontend.SetSockOptString(zmq.SUBSCRIBE, "")
+	frontend.SetSubscribe("")
 
 	// Shunt messages out to our own subscribers
 	for {


### PR DESCRIPTION
Socket option methods were recently added in gozmq.  This commit updates the Go examples to use these new methods.
