### PR TITLE
Need to increase ZMQ_SNDHWM a bit more in syncpub example

### DIFF
--- a/examples/C/syncpub.c
+++ b/examples/C/syncpub.c
@@ -11,7 +11,7 @@ int main (void)
     void *publisher = zmq_socket (context, ZMQ_PUB);
     zmq_bind (publisher, "tcp://*:5561");
 
-    int sndhwm = 1000000;
+    int sndhwm = 1100000;
     zmq_setsockopt (publisher, ZMQ_SNDHWM, &sndhwm, sizeof (int));
 
     //  Socket to receive signals


### PR DESCRIPTION
On my machine messages got lost with HWM of exactly 1M.

According to documentation of zmq_setsockopt the actual limit might be much
smaller than the provided value. Is there a possibility to find out how much
exactly?
