### PR TITLE
Fix for working identities in ppqueue.c

### DIFF
--- a/examples/C/ppqueue.c
+++ b/examples/C/ppqueue.c
@@ -24,7 +24,7 @@ s_worker_new (zframe_t *identity)
 {
     worker_t *self = (worker_t *) zmalloc (sizeof (worker_t));
     self->identity = identity;
-    self->id_string = zframe_strdup (identity);
+    self->id_string = zframe_strhex (identity);
     self->expiry = zclock_time ()
                  + HEARTBEAT_INTERVAL * HEARTBEAT_LIVENESS;
     return self;


### PR DESCRIPTION
ppqueue.c fails to work with more than one ppworker.  This is due to using `char* id_string` with raw auto-generated router identities. Changing the `id_string` in ppqueue's `s_worker_new` to `zframe_strhex` fixes this issue.
