### PR TITLE
Fix for subtree in clone.py

### DIFF
--- a/examples/Python/clone.py
+++ b/examples/Python/clone.py
@@ -51,7 +51,7 @@ class Clone(object):
     @subtree.setter
     def subtree(self, subtree):
         """Sends [SUBTREE][subtree] to the agent"""
-        self._subtree = None
+        self._subtree = subtree
         self.pipe.send_multipart(["SUBTREE", subtree])
 
     def connect(self, address, port):


### PR DESCRIPTION
Setter isn't saving subtree.
In clonecli6.py

``` python
clone = Clone()
clone.subtree = SUBTREE
clone.connect("tcp://localhost", 5556)
clone.connect("tcp://localhost", 5566)
print clone.subtree
```

prints

```
None
```

instead of 

```
/client/
```
