### PR TITLE
Fix incorrect variable name (Ch. 2)

### DIFF
--- a/chapter2.txt
+++ b/chapter2.txt
@@ -697,8 +697,8 @@ How do we connect the sink to the workers? The PUSH/PULL sockets are one-way onl
 It doesn't take much new code in the sink:
 
 [[code type="fragment" name="killsignal"]]
-void *control = zmq_socket (context, ZMQ_PUB);
-zmq_bind (control, "tcp://*:5559");
+void *controller = zmq_socket (context, ZMQ_PUB);
+zmq_bind (controller, "tcp://*:5559");
 ...
 //  Send kill signal to workers
 s_send (controller, "KILL");

--- a/fragments/C/killsignal.c
+++ b/fragments/C/killsignal.c
@@ -1,5 +1,5 @@
-void *control = zmq_socket (context, ZMQ_PUB);
-zmq_bind (control, "tcp://*:5559");
+void *controller = zmq_socket (context, ZMQ_PUB);
+zmq_bind (controller, "tcp://*:5559");
 ...
 //  Send kill signal to workers
 s_send (controller, "KILL");


### PR DESCRIPTION
In the example code showing how the sink shuts down workers in a parallel pipeline,

``` C
void *control = zmq_socket (context, ZMQ_PUB);
zmq_bind (control, "tcp://*:5559");
…
//  Send kill signal to workers
s_send (controller, "KILL");
```

The socket is declared as `control` but later referred to as `controller`.
