### PR TITLE
fix ruby psenvpub/psenvsub example

### DIFF
--- a/examples/Ruby/psenvpub.rb
+++ b/examples/Ruby/psenvpub.rb
@@ -1,15 +1,19 @@
 #! /usr/bin/env ruby
-require 'zmq'
+
+require 'ffi-rzmq'
+
 context = ZMQ::Context.new
 publisher = context.socket ZMQ::PUB
 publisher.bind "tcp://*:5563"
-while true
-  publisher.send 'A',ZMQ::SNDMORE
-  publisher.send "We don't want to see this."
 
-  publisher.send 'B',ZMQ::SNDMORE
-  publisher.send "We would like to see this."
+loop do
+  publisher.send_string 'A', ZMQ::SNDMORE
+  publisher.send_string "We don't want to see this."
+
+  publisher.send_string 'B', ZMQ::SNDMORE
+  publisher.send_string "We would like to see this."
 
   sleep 1
 end
+
 publisher.close

--- a/examples/Ruby/psenvsub.rb
+++ b/examples/Ruby/psenvsub.rb
@@ -1,12 +1,19 @@
 #! /usr/bin/env ruby
-require 'zmq'
+
+require 'ffi-rzmq'
+
 context = ZMQ::Context.new
 subscriber = context.socket ZMQ::SUB
-subscriber.connect "tcp://*:5563"
-subscriber.setsockopt ZMQ::SUBSCRIBE,'B'
-while true
+subscriber.connect "tcp://localhost:5563"
+subscriber.setsockopt ZMQ::SUBSCRIBE, 'B'
+
+loop do
   # Two recv s because of the multi-part message.
-  address = subscriber.recv
-  content = subscriber.recv
+  address = ''
+  subscriber.recv_string address
+
+  content = ''
+  subscriber.recv_string content
+
   puts "[#{address}] #{content}"
 end


### PR DESCRIPTION
- convert to using ffi-rzmq
- minor stylistic changes
