### PR TITLE
Change url protocol for git clone

### DIFF
--- a/chapter1.txt
+++ b/chapter1.txt
@@ -35,7 +35,7 @@ We assume you are using at least version 3.2 of 0MQ. We assume you are using a L
 The examples live in a public [https://github.com/imatix/zguide GitHub repository]. The simplest way to get all the examples is to clone this repository:
 
 [[code]]
-git clone --depth=1 git://github.com/imatix/zguide.git
+git clone --depth=1 https://github.com/imatix/zguide.git
 [[/code]]
 
 Next, browse the examples subdirectory. You'll find examples by language. If there are examples missing in a language you use, you're encouraged to [http://zguide.zeromq.org/main:translate submit a translation]. This is how this text became so useful, thanks to the work of many people. All examples are licensed under MIT/X11.


### PR DESCRIPTION
Github.com doesn't support git:// protocol anymore.
