### PR TITLE
Add Node.js version of "identity" example

### DIFF
--- a/examples/Node.js/identity.js
+++ b/examples/Node.js/identity.js
@@ -1,0 +1,26 @@
+//  Demonstrate request-reply identities
+
+var zmq = require("zmq"),
+    zhelpers = require('./zhelpers');
+
+var sink = zmq.socket("router");
+sink.bind("inproc://example");
+
+sink.on("message", zhelpers.dumpFrames);
+
+//  First allow 0MQ to set the identity
+var anonymous = zmq.socket("req");
+anonymous.connect("inproc://example");
+anonymous.send("ROUTER uses generated UUID");
+
+//  Then set the identity ourselves
+var identified = zmq.socket("req");
+identified.identity = "PEER2";
+identified.connect("inproc://example");
+identified.send("ROUTER uses REQ's socket identity");
+
+setTimeout(function() {
+  anonymous.close();
+  identified.close();
+  sink.close();
+}, 250);

--- a/examples/Node.js/zhelpers.js
+++ b/examples/Node.js/zhelpers.js
@@ -1,0 +1,46 @@
+// Return the buffer's length as a three-character,
+// zero-padded string (e.g. printf's `%03d`)
+function bufferLength(buffer) {
+  var lenStr = "" + buffer.length;
+  while (lenStr.length < 3) {
+    lenStr = "0" + lenStr;
+  }
+
+  return lenStr;
+}
+
+// Return the buffer's contents as printable text if every
+// character is printable, or as hexadecimal otherwise
+function formatBuffer(buffer) {
+  for (var i = 0; i < buffer.length; i++) {
+    if (buffer[i] < 32 || buffer[i] > 127) {
+      return buffer.toString("hex")
+    }
+  }
+
+  return buffer.toString("utf8");
+}
+
+module.exports = {
+  dumpFrames: function() {
+    var frames;
+    if (arguments.length == 1) {
+      var arg = arguments[0];
+      if (Array.isArray(arg)) {
+        // Single argument is an array of frames (buffers)
+        frames = arg;
+      } else {
+        // Single argument is a single frame (buffer)
+        frames = [arg];
+      }
+    } else {
+      // Multiple arguments; each is a frame (buffer)
+      frames = Array.prototype.slice.call(arguments);
+    }
+
+    console.log("----------------------------------------");
+    frames.forEach(function(frame) {
+      console.log("[%s] %s", bufferLength(frame), formatBuffer(frame));
+    });
+  }
+};


### PR DESCRIPTION
This is a Node.js implementation of the "identity" example in the "Identities and Addresses" section of chapter 3. It also includes a basic version of `s_dump` extracted into a separate module.

Sample run:

```
$ node identity.js
----------------------------------------
[005] 00800041a7
[000]
[026] ROUTER uses generated UUID
----------------------------------------
[005] PEER2
[000]
[033] ROUTER uses REQ's socket identity
```
