### PR TITLE
fixed purging of expired workers in WorkerQueue

### DIFF
--- a/examples/Python/ppqueue.py
+++ b/examples/Python/ppqueue.py
@@ -35,9 +35,8 @@ class WorkerQueue(object):
         t = time.time()
         expired = []
         for address,worker in self.queue.iteritems():
-            if t < worker.expiry:  # Worker is alive
-                break
-            expired.append(address)
+            if t > worker.expiry:  # Worker expired
+                expired.append(address)
         for address in expired:
             print "W: Idle worker expired: %s" % address
             self.queue.pop(address, None)


### PR DESCRIPTION
It seems that if first worker was alive then no checking was performed for all other workers and thus this can lead to a whole bunch of dead workers in queue.
