### PR TITLE
Update to 0MQ4 + cleanup

### DIFF
--- a/examples/Haskell/ZHelpers.hs
+++ b/examples/Haskell/ZHelpers.hs
@@ -1,13 +1,9 @@
 module ZHelpers where
 
-import System.ZMQ3.Monadic
+import System.ZMQ4.Monadic
 
 import Numeric (showHex)
 
---import Control.Monad (foldM)
---import Control.Applicative ((<*>))
-
---import Data.ByteString.Char8 (pack, unpack, ByteString, cons, empty)
 import Data.ByteString.Char8 (pack, unpack)
 import Data.Char (ord)
 import Text.Printf (printf)
@@ -26,34 +22,19 @@ dumpMsg msg_parts = do
 dumpSock :: Receiver t => Socket z t  -> ZMQ z ()
 dumpSock sock = fmap reverse (receiveMulti sock) >>= liftIO . dumpMsg
 
-
 -- In General Since We use Randomness, You should Pass in
 -- an StdGen, but for simplicity we just use newStdGen
 setRandomIdentity :: Socket z t -> ZMQ z ()
-setRandomIdentity sock = (liftIO $ genUniqueId) >>= (\ident -> setIdentity (restrict $ pack ident) sock)
+setRandomIdentity sock = liftIO genUniqueId >>= (\ident -> setIdentity (restrict $ pack ident) sock)
 
 
 -- You probably want to use a ext lib to generate random unique id in production code
-genUniqueId :: IO (String)
+genUniqueId :: IO String
 genUniqueId = do
-    gen <- liftIO $ newStdGen
+    gen <- liftIO newStdGen
     let (val1, gen') = randomR (0 :: Int, 65536) gen
     let (val2, _) = randomR (0 :: Int, 65536) gen'
     return $ show val1 ++ show val2
-
-
---zpipe :: Context -> (Socket Pair -> Socket Pair -> IO a) -> IO a
---zpipe ctx func = withSocket ctx Pair $ \sock_a -> do
---    setOption sock_a (Linger 0)
---    setOption sock_a (HighWM 1)
---    withSocket ctx Pair $ \sock_b -> do
---        setOption sock_b (Linger 0)
---        setOption sock_b (HighWM 1)
---        bytes <- genKBytes 8
---        let iface = "inproc://" ++ prettyPrint bytes
---        bind sock_a iface
---        connect sock_b iface
---        func sock_a sock_b
 
 -- In General Since We use Randomness, You should Pass in
 -- an StdGen, but for simplicity we just use newStdGen

--- a/examples/Haskell/asyncsrv.hs
+++ b/examples/Haskell/asyncsrv.hs
@@ -1,11 +1,16 @@
+-- |
+-- Asynchronous client-to-server (DEALER to ROUTER) p.111
+-- Compile with -threaded
+
 module Main where
 
-import System.ZMQ3.Monadic
+import System.ZMQ4.Monadic
 import ZHelpers (setRandomIdentity)
 import Control.Concurrent (threadDelay)
 import Data.ByteString.Char8 (pack, unpack)
 import Control.Monad (forever, forM_, replicateM_)
 import System.Random (randomRIO)
+import Text.Printf
 
 clientTask :: String -> ZMQ z ()
 clientTask ident = do
@@ -18,7 +23,7 @@ clientTask ident = do
             poll 10 -- timeout of 10 ms
                 [Sock client [In] -- wait for incoming event 
                 $ Just $ -- if it happens do
-                    \_ -> receive client >>= \msg -> liftIO $ putStrLn $ unwords ["Client", ident, "has received back from worker its msg \"", (unpack msg), "\""]] 
+                    \_ -> receive client >>= liftIO . printf "Client %s has received back from worker its msg \"%s\"\n" ident . unpack ] 
               
         send client [] (pack $ unwords ["Client", ident, "sends request", show i])
 

--- a/examples/Haskell/hwclient.hs
+++ b/examples/Haskell/hwclient.hs
@@ -7,7 +7,7 @@
 
 module Main where
 
-import System.ZMQ3.Monadic
+import System.ZMQ4.Monadic
 import Control.Monad (forM_)
 import Data.ByteString.Char8 (pack, unpack)
 

--- a/examples/Haskell/hwserver.hs
+++ b/examples/Haskell/hwserver.hs
@@ -6,7 +6,7 @@
 
 module Main where
 
-import System.ZMQ3.Monadic
+import System.ZMQ4.Monadic
 import Control.Monad (forever)
 import Data.ByteString.Char8 (pack, unpack)
 import Control.Concurrent (threadDelay)

--- a/examples/Haskell/identity.hs
+++ b/examples/Haskell/identity.hs
@@ -1,9 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import System.ZMQ3.Monadic
+import System.ZMQ4.Monadic
 import ZHelpers (dumpSock)
-
 
 main :: IO ()
 main =

--- a/examples/Haskell/interrupt.hs
+++ b/examples/Haskell/interrupt.hs
@@ -3,23 +3,23 @@ module Main where
 import System.Posix.Signals (installHandler, Handler(Catch), sigINT, sigTERM)
 import Control.Concurrent.MVar (modifyMVar_, newMVar, withMVar, MVar)
 
-import System.ZMQ
+import System.ZMQ4
 
 handler :: MVar Int -> IO ()
 handler s_interrupted = modifyMVar_ s_interrupted (return . (+1))
 
 main :: IO ()
-main = withContext 1 $ \context -> do
-    withSocket context Rep $ \socket -> do
+main = withContext $ \ctx ->
+    withSocket ctx Rep $ \socket -> do
       bind socket "tcp://*:5555"
       s_interrupted <- newMVar 0
       installHandler sigINT (Catch $ handler s_interrupted) Nothing
       installHandler sigTERM (Catch $ handler s_interrupted) Nothing
       recvFunction s_interrupted socket
       
-recvFunction :: (Ord a, Num a) => MVar a -> Socket b -> IO ()
+recvFunction :: (Ord a, Num a, Receiver b) => MVar a -> Socket b -> IO ()
 recvFunction mi sock = do
-    receive sock []
+    receive sock 
     withMVar mi (\val -> if val > 0
         then putStrLn "W: Interrupt Received. Killing Server"
         else recvFunction mi sock)

--- a/examples/Haskell/msgqueue.hs
+++ b/examples/Haskell/msgqueue.hs
@@ -1,12 +1,12 @@
 -- |
--- Simple message queuing broker in Haskell
+-- Simple message queuing broker (p.53)
 -- Same as request-reply broker but using QUEUE device
 -- 
--- Orginally translated to Haskell by ERDI Gergo http://gergo.erdi.hu/
+-- Use it with `rrclient.hs` and `rrworker.hs`
 
 module Main where
 
-import System.ZMQ3
+import System.ZMQ4
 
 main :: IO ()
 main = 

--- a/examples/Haskell/mspoller.hs
+++ b/examples/Haskell/mspoller.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE OverloadedStrings #-}
 -- |
--- Multiple socket poller in Haskell
+-- Multiple socket poller in Haskell (p.43)
 -- This version uses poll
 --
--- Originally translated to Haskell by Sebastian Nowicki <sebnow@gmail.com>
+-- Test it with `wuserver.hs`
 
 module Main where
 
 import Control.Monad (forever, when)
 import Data.ByteString.Char8 (unpack)
-import System.ZMQ3
+import System.ZMQ4
 import Control.Applicative ((<$>))
 
 main :: IO ()
@@ -21,13 +21,13 @@ main =
             setIdentity (restrict "vent receiver") receiver
             connect subscriber "tcp://localhost:5556"
             subscribe subscriber "10001"
-            forever $ do
+            forever $
                 poll (-1) [Sock receiver [In] (Just $ processEvts receiver), Sock subscriber [In] (Just $ processEvts subscriber)]
 
 processEvts :: (Receiver a) => Socket a -> [Event] -> IO ()
-processEvts sock evts = do
+processEvts sock evts = 
     when (In `elem` evts) $ do
         msg <- unpack <$> receive sock
         ident <- unpack <$> identity sock
-        putStrLn $ unwords $ ["Processing ", ident, msg]
+        putStrLn $ unwords ["Processing ", ident, msg]
 

--- a/examples/Haskell/mtrelay.hs
+++ b/examples/Haskell/mtrelay.hs
@@ -1,11 +1,10 @@
 -- |
--- Multithreaded relay in Haskell
+-- Multithreaded relay (p.68)
 -- 
--- Originally translated to Haskell by ERDI Gergo http://gergo.erdi.hu/
 
 module Main where
 
-import System.ZMQ3.Monadic (ZMQ, runZMQ, socket, Pair(..), bind, connect, receive, send, async, liftIO)
+import System.ZMQ4.Monadic 
 
 import Data.ByteString.Char8 (pack, unpack)
 

--- a/examples/Haskell/mtserver.hs
+++ b/examples/Haskell/mtserver.hs
@@ -1,41 +1,40 @@
 {-# LANGUAGE OverloadedStrings #-}
 -- |
--- Multithreaded Hello World server in Haskell
--- 
--- Translated to Haskell by ERDI Gergo http://gergo.erdi.hu/
-
+-- Multithreaded Hello World server (p.65)
+-- (Client) REQ >-> ROUTER (Proxy) DEALER >-> REP ([Worker])
+-- The client is provided by `hwclient.hs`
+-- Compile with -threaded
+ 
 module Main where
 
-import System.ZMQ3.Monadic
+import System.ZMQ4.Monadic
 import Control.Monad (forever, replicateM_)
 import Data.ByteString.Char8 (unpack)
 import Control.Concurrent (threadDelay)
 import Text.Printf
 
-
 main :: IO ()
 main =
     runZMQ $ do
-        -- Socket to talk to clients
-        clients <- socket Router
-        bind clients "tcp://*:5555"
-    
+        -- Server frontend socket to talk to clients
+        server <- socket Router
+        bind server "tcp://*:5555"
+
         -- Socket to talk to workers
         workers <- socket Dealer
         bind workers "inproc://workers"
       
         -- using inproc (inter-thread) we expect to share the same context
         replicateM_ 5 (async worker)
-        
         -- Connect work threads to client threads via a queue
-        proxy clients workers Nothing
+        proxy server workers Nothing
 
 worker :: ZMQ z ()
 worker = do
     receiver <- socket Rep
     connect receiver "inproc://workers"
     forever $ do
-      receive receiver >>= liftIO . printf "Received request:%s\n" . unpack    
-      -- Simulate doing some 'work' for 1 second
-      liftIO $ threadDelay (1 * 1000 * 1000)  
-      send receiver [] "World"
+        receive receiver >>= liftIO . printf "Received request:%s\n" . unpack    
+        -- Simulate doing some 'work' for 1 second
+        liftIO $ threadDelay (1 * 1000 * 1000)  
+        send receiver [] "World"

--- a/examples/Haskell/psenvpub.hs
+++ b/examples/Haskell/psenvpub.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 -- |
--- Pub/Sub envelope publisher
+-- Pub/Sub envelope publisher p.75
 -- 
 module Main where
 
-import System.ZMQ3.Monadic (runZMQ, socket, bind, send, Pub(..), Flag(SendMore), liftIO)
+import System.ZMQ4.Monadic
 import Control.Concurrent (threadDelay)
 import Control.Monad (forever)
 

--- a/examples/Haskell/psenvsub.hs
+++ b/examples/Haskell/psenvsub.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 -- |
--- Pub/Sub envelope subscriber
+-- Pub/Sub envelope subscriber (p.76)
 -- 
 module Main where
     
-import System.ZMQ3.Monadic (runZMQ, socket, connect, subscribe, receive, moreToReceive, Sub(..), liftIO)
+import System.ZMQ4.Monadic
 import Data.ByteString.Char8 (unpack)
 import Control.Monad (when)
 import Text.Printf
@@ -15,14 +15,17 @@ main =
         subscriber <- socket Sub
         connect subscriber "tcp://localhost:5563"
         subscribe subscriber "B"
-        -- read envelope with address
-        receive subscriber >>= \addr -> liftIO $ printf "Address is %s\n" (unpack addr)
-        --  loop contents
+
+        -- start listening for pub messages
         loop subscriber
+
     where
         loop subscriber = do
+            -- read envelope with address
+            receive subscriber >>= \addr -> liftIO $ printf "Address is %s\n" (unpack addr) 
+            -- read message content
             more <- moreToReceive subscriber
             when more $ do
                 contents <- receive subscriber 
                 liftIO $ putStrLn (unpack contents)
-                loop subscriber
+            loop subscriber

--- a/examples/Haskell/rrbroker.hs
+++ b/examples/Haskell/rrbroker.hs
@@ -1,7 +1,6 @@
 module Main where
 
-import System.ZMQ3.Monadic
-import Control.Monad (forever)    
+import System.ZMQ4.Monadic
 
 main :: IO ()
 main = 
@@ -10,4 +9,5 @@ main =
         bind frontend "tcp://*:5559"
         backend <- socket Dealer
         bind backend "tcp://*:5560"
+        
         proxy frontend backend Nothing

--- a/examples/Haskell/rrclient.hs
+++ b/examples/Haskell/rrclient.hs
@@ -1,14 +1,15 @@
 {-# LANGUAGE OverloadedStrings #-}
 -- |
--- Hello World client in Haskell
+-- Request/Reply Hello World with broker (p.50) 
 -- Binds REQ socket to tcp://localhost:5559
 -- Sends "Hello" to server, expects "World" back
 -- 
--- Originally translated to Haskell by ERDI Gergo http://gergo.erdi.hu/
+-- Use with `rrbroker.hs` and `rrworker.hs`
+-- You need to start the broker first !
 
 module Main where
 
-import System.ZMQ3.Monadic (runZMQ, socket, connect, send, receive, Req(..), liftIO)
+import System.ZMQ4.Monadic 
 import Control.Monad (forM_)
 import Data.ByteString.Char8 (unpack)
 import Text.Printf

--- a/examples/Haskell/rrworker.hs
+++ b/examples/Haskell/rrworker.hs
@@ -5,11 +5,10 @@
 -- Connect REP socket to tcp://*:5560
 -- Expects "Hello" from client, replies with "World"
 -- 
--- Originally translated to Haskell by ERDI Gergo http://gergo.erdi.hu/
 
 module Main where
 
-import System.ZMQ3.Monadic (runZMQ, socket, connect, send, receive, Rep(..), liftIO)
+import System.ZMQ4.Monadic
 import Control.Monad (forever)
 import Data.ByteString.Char8 (unpack)
 import Control.Concurrent (threadDelay)

--- a/examples/Haskell/rtreq.hs
+++ b/examples/Haskell/rtreq.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
+-- |
+-- Router broker and REQ workers (p.92)
+
 module Main where
 
-import System.ZMQ3.Monadic (ZMQ, Socket, runZMQ, socket, connect, bind, receive, send, Router(..), Req(..), Flag(SendMore), liftIO)
+import System.ZMQ4.Monadic
 
 import Control.Concurrent (threadDelay, forkIO)
 import Control.Concurrent.MVar (withMVar, newMVar, MVar)
@@ -9,7 +12,7 @@ import Data.ByteString.Char8 (unpack)
 import Control.Monad (replicateM_, unless)
 import ZHelpers (setRandomIdentity)
 import Text.Printf
-import Data.Time.Clock
+import Data.Time.Clock (diffUTCTime, getCurrentTime, UTCTime)
 import System.Random
 
 nbrWorkers :: Int
@@ -52,7 +55,7 @@ main =
 
         liftIO $ replicateM_ nbrWorkers (forkIO $ workerThread lock)
 
-        start <- liftIO $ getCurrentTime
+        start <- liftIO getCurrentTime
         clientTask client start
 
         -- You need to give some time to the workers so they can exit properly
@@ -63,8 +66,8 @@ main =
         clientTask = loop nbrWorkers where
             loop c sock start = unless (c <= 0) $ do
                 -- Next message is the leaset recently used worker
-                identity <- receive sock
-                send sock [SendMore] identity
+                ident <- receive sock
+                send sock [SendMore] ident
                 -- Envelope delimiter
                 receive sock
                 -- Ready signal from worker
@@ -73,8 +76,8 @@ main =
                 -- Send delimiter
                 send sock [SendMore] ""
                 -- Send Work unless time is up
-                now <- liftIO $ getCurrentTime
-                if (c /= nbrWorkers || diffUTCTime now start > 5)
+                now <- liftIO getCurrentTime
+                if c /= nbrWorkers || diffUTCTime now start > 5
                 then do
                     send sock [] "Fired!"
                     loop (c-1) sock start 

--- a/examples/Haskell/syncsub.hs
+++ b/examples/Haskell/syncsub.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 -- |
--- Node coordination Subscriber
--- 
+-- Node coordination Subscriber (p.72)
+-- Run as much sub as necessary (see syncpub subscribersExpected) 
+
 module Main where
     
 
-import System.ZMQ3.Monadic (ZMQ, Socket, runZMQ, socket, connect, receive, send, subscribe, Sub(..), Req(..), liftIO)
+import System.ZMQ4.Monadic
 import Data.ByteString.Char8 (unpack)
 import Control.Concurrent (threadDelay)
 import Text.Printf
@@ -34,10 +35,10 @@ main =
 
 
     where
-        countUpdates :: Socket z Sub -> ZMQ z (Int) 
+        countUpdates :: Socket z Sub -> ZMQ z Int 
         countUpdates = loop 0 where
             loop val sock = do
                 msg <- receive sock
                 if unpack msg == "END"
                 then return val 
-                else do loop(val + 1) sock
+                else loop(val + 1) sock

--- a/examples/Haskell/tasksink.hs
+++ b/examples/Haskell/tasksink.hs
@@ -3,24 +3,23 @@
 -- Binds PULL socket to tcp://localhost:5558
 -- Collects results from workers via that socket
 -- 
--- Translated to Haskell by ERDI Gergo http://gergo.erdi.hu/
 
 module Main where
 
-import System.ZMQ3.Monadic(runZMQ, socket, bind, receive, Pull(..), liftIO)
+import System.ZMQ4.Monadic
 import Control.Monad (forM_)
 import System.IO (hSetBuffering, stdout, BufferMode(..))
 import Data.Time.Clock (getCurrentTime, diffUTCTime)
 
 main :: IO ()
-main = do
+main = 
     runZMQ $ do
         receiver <- socket Pull
         bind receiver "tcp://*:5558"
         -- Wait for start of batch
         receive receiver
         -- Start our clock now
-        startTime <- liftIO $ getCurrentTime
+        startTime <- liftIO getCurrentTime
         liftIO $ hSetBuffering stdout NoBuffering
 
         -- Process 100 confirmations    
@@ -28,7 +27,7 @@ main = do
             receive receiver
             liftIO $ putStr $ if i `mod` 10 == 0 then ":" else "."
           
-        endTime <- liftIO $ getCurrentTime
+        endTime <- liftIO getCurrentTime
         let elapsedTime = diffUTCTime endTime startTime
             elapsedMsec = elapsedTime * 1000
         liftIO $ putStrLn $ unwords ["Total elapsed time:", show elapsedMsec, "msecs"]

--- a/examples/Haskell/tasksink2.hs
+++ b/examples/Haskell/tasksink2.hs
@@ -1,25 +1,18 @@
 {-# LANGUAGE OverloadedStrings #-}
 -- |
--- Task sink
--- Binds PULL socket to tcp://localhost:5558
--- Collects results from workers via that socket
--- 
--- Originally translated to Haskell by ERDI Gergo http://gergo.erdi.hu/
+-- Task sink - design 2
+-- Add pub-sub flow to receive and respond to kill signal
 
 module Main where
 
-import System.ZMQ3.Monadic(runZMQ, socket, bind, receive, send, Pull(..), Pub(..), liftIO)
+import System.ZMQ4.Monadic
 import Control.Monad (forM_)
 import System.IO (hSetBuffering, stdout, BufferMode(..))
 import Data.Time.Clock (getCurrentTime, diffUTCTime)
 
 main :: IO ()
-main = do
-
-
-
+main = 
     runZMQ $ do
-
         receiver <- socket Pull
         bind receiver "tcp://*:5558"
 
@@ -30,14 +23,14 @@ main = do
         receive receiver
         
         -- Start our clock now
-        startTime <- liftIO $ getCurrentTime
+        startTime <- liftIO getCurrentTime
         liftIO $ hSetBuffering stdout NoBuffering
         -- Process 100 confirmations    
         forM_ [1..100] $ \i -> do
             receive receiver
             liftIO $ putStr $ if i `mod` 10 == 0 then ":" else "."
-          
-        endTime <- liftIO $ getCurrentTime
+            
+        endTime <- liftIO getCurrentTime
         let elapsedTime = diffUTCTime endTime startTime
             elapsedMsec = elapsedTime * 1000
         liftIO $ putStrLn $ unwords ["Total elapsed time:", show elapsedMsec, "msecs"]

--- a/examples/Haskell/taskvent.hs
+++ b/examples/Haskell/taskvent.hs
@@ -1,13 +1,13 @@
 -- |
--- Task ventilator
+-- Task ventilator (p.17)
 -- Binds PUSH socket to tcp://*:5557
 -- Sends batch of tasks to workers via that socket
 -- 
--- Translated to Haskell by ERDI Gergo http://gergo.erdi.hu/
+-- You need `taskwork.hs` as workers and `tasksink.hs` as sink 
 
 module Main where
 
-import System.ZMQ3.Monadic(runZMQ, socket, bind, connect, send, Push(..), liftIO)
+import System.ZMQ4.Monadic(runZMQ, socket, bind, connect, send, Push(..), liftIO)
 import Control.Monad (replicateM)
 import Data.ByteString.Char8 (pack)
 import System.Random (randomRIO)
@@ -32,7 +32,7 @@ main =
 
             -- Send 100 tasks, calculate total workload
             workload <- sum <$> replicateM 100 (do
-                workload' <- liftIO $ (randomRIO (1, 100) :: IO Int)
+                workload' <- liftIO (randomRIO (1, 100) :: IO Int)
                 send sender [] (pack $ show workload') 
                 return workload')
               

--- a/examples/Haskell/taskwork.hs
+++ b/examples/Haskell/taskwork.hs
@@ -1,15 +1,14 @@
 -- |
--- Task worker
+-- Task worker (p.18)
 -- Connects PULL socket to tcp://localhost:5557
--- Collects workloads from ventilator via that socket
+-- Collects workloads from ventilator via that socket (see `taskvent.hs`)
 -- Connects PUSH socket to tcp://localhost:5558
--- Sends results to sink via that socket
+-- Sends results to sink via that socket (see `tasksink.hs`)
 -- 
--- Translated to Haskell by ERDI Gergo http://gergo.erdi.hu/
 
 module Main where
 
-import System.ZMQ3.Monadic (runZMQ, socket, connect, send, receive, Pull(..), Push(..), liftIO)
+import System.ZMQ4.Monadic 
 import Control.Monad (forever)
 import Data.ByteString.Char8 (unpack, empty)
 import Control.Applicative ((<$>))

--- a/examples/Haskell/version.hs
+++ b/examples/Haskell/version.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import System.ZMQ3 (version)
+import System.ZMQ4 (version)
 import Text.Printf (printf)
 
 main :: IO ()

--- a/examples/Haskell/wuclient.hs
+++ b/examples/Haskell/wuclient.hs
@@ -4,31 +4,40 @@
 -- Binds SUB socket to tcp://localhost:5556
 -- Collects weather updates and finds avg temp in zipcode
 -- 
--- Translated to Haskell by ERDI Gergo http://gergo.erdi.hu/
 
 module Main where
 
-import System.ZMQ3.Monadic
+import System.ZMQ4.Monadic
 import Control.Monad (replicateM)
+import Control.Applicative((<$>), (<*>))
 import Data.ByteString.Char8 (unpack, pack)
-import System.Environment (getArgs)
+import Text.Printf
+import qualified Control.Foldl as L
+
+-- | Average uses applicative with `Control.Foldl` in order to traverse the list only once.
+average :: L.Fold Double Double
+average = (/) <$> L.sum <*> L.genericLength
+
+mapped :: (a -> b) -> L.Fold b r -> L.Fold a r
+mapped f (L.Fold step begin done) = L.Fold step' begin done
+  where
+    step' x = step x . f
 
 main :: IO ()
-main = do    
-  args <- getArgs
-  let zipcode = case args of
-        [zipcode] -> zipcode
-        _ -> "10001"
-      
+main =
   runZMQ $ do
-      subscriber <- socket Sub
-      connect subscriber "tcp://localhost:5556"
-      subscribe subscriber (pack zipcode)
-            
-      temperatures <- replicateM 5 $ do
-          update <- receive subscriber
-          let [zipcode, temperature, humidity] = map read $ words $ unpack update
-          return temperature
-      
-      let avgTemp = fromIntegral (sum temperatures) / fromIntegral (length temperatures)
-      liftIO $ putStrLn $ unwords ["Average temperature for zipcode", zipcode, "was", show avgTemp]
+    subscriber <- socket Sub
+    connect subscriber "tcp://localhost:5556"
+    -- Subscribe for NY City zipcode
+    subscribe subscriber (pack "10001")
+        
+    records <- replicateM 5 $ do
+      update <- receive subscriber
+      let [_, temp, hum] = map read $ words $ unpack update
+      return (temp, hum)
+
+    liftIO $ printf "NY City: avg temperature of %.1f°C and avg humidity of %.1f%%\n" (avgTemp records) (avgHum records) 
+
+    where
+       avgTemp = L.fold (mapped fst average) 
+       avgHum  = L.fold (mapped snd average) 

--- a/examples/Haskell/wuproxy.hs
+++ b/examples/Haskell/wuproxy.hs
@@ -6,7 +6,7 @@
 
 module Main where
 
-import System.ZMQ3.Monadic (runZMQ, socket, connect, bind, receive, send, moreToReceive, subscribe, Sub(..), Pub(..), Flag(SendMore), liftIO)
+import System.ZMQ4.Monadic
 import Control.Monad (forever)
 
 main :: IO ()

--- a/examples/Haskell/wuserver.hs
+++ b/examples/Haskell/wuserver.hs
@@ -4,11 +4,10 @@
 -- Binds PUB socket to tcp://*:5556
 -- Publishes random weather updates
 -- 
--- Translated to Haskell by ERDI Gergo http://gergo.erdi.hu/
 
 module Main where
 
-import System.ZMQ3.Monadic
+import System.ZMQ4.Monadic
 import Control.Monad (forever)
 import Data.ByteString.Char8 (pack)
 import System.Random (randomRIO)

--- a/examples/Haskell/zguide.cabal
+++ b/examples/Haskell/zguide.cabal
@@ -1,0 +1,217 @@
+Name: zguide-examples-haskell
+Version: 1.0.0
+Cabal-Version: >=1.10
+Build-Type: Simple
+License: BSD3
+License-File: LICENSE
+Copyright: 2014 Pierre Radermecker
+Author: Pierre Radermecker
+Maintainer: PierreR@pi3r.com
+Bug-Reports: https://github.com/PierreR/zguide
+Tested-With: GHC == 7.6.3
+Synopsis: ZMQ haskell example
+Description: 
+Category: 
+Source-Repository head
+    Type: git
+    Location: https://github.com/PierreR/zguide
+
+executable version
+  default-language: Haskell2010
+  main-is:  version.hs
+  build-depends:  base >= 4,
+                  zeromq4-haskell  >= 0.1
+
+executable hwclient
+  default-language: Haskell2010
+  main-is:  hwclient.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  zeromq4-haskell  >= 0.1
+
+executable hwserver
+  default-language: Haskell2010
+  main-is:  hwserver.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  zeromq4-haskell  >= 0.1
+
+executable wuserver
+  default-language: Haskell2010
+  main-is:  wuserver.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  random,
+                  zeromq4-haskell  >= 0.1
+executable mspoller
+  default-language: Haskell2010
+  main-is:  mspoller.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  zeromq4-haskell  >= 0.1
+executable wuclient
+  default-language: Haskell2010
+  main-is:  wuclient.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  foldl >= 1.0,
+                  zeromq4-haskell  >= 0.1
+                  
+executable wuproxy
+  default-language: Haskell2010
+  main-is:  wuproxy.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  zeromq4-haskell >= 0.1
+
+executable identity
+  default-language: Haskell2010
+  main-is:  identity.hs
+  other-modules: ZHelpers
+  build-depends:  base >= 4,
+                  bytestring,
+                  random,
+                  zeromq4-haskell  >= 0.1
+
+executable taskvent
+  default-language: Haskell2010
+  main-is:  taskvent.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  random,
+                  zeromq4-haskell  >= 0.1
+executable taskwork
+  default-language: Haskell2010
+  main-is:  taskwork.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  zeromq4-haskell  >= 0.1
+executable taskwork2
+  default-language: Haskell2010
+  main-is:  taskwork2.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  zeromq4-haskell  >= 0.1
+executable tasksink
+ default-language: Haskell2010
+ main-is:  tasksink.hs
+ build-depends:  base >= 4,
+                 bytestring,
+                 time,
+                 zeromq4-haskell  >= 0.1
+executable tasksink2
+ default-language: Haskell2010
+ main-is:  tasksink2.hs
+ build-depends:  base >= 4,
+                 bytestring,
+                 time,
+                 zeromq4-haskell  >= 0.1                                   
+
+executable rrclient
+  default-language: Haskell2010
+  main-is:  rrclient.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  zeromq4-haskell  >= 0.1
+executable rrbroker
+  default-language: Haskell2010
+  main-is:  rrbroker.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  zeromq4-haskell  >= 0.1
+executable msgqueue
+  default-language: Haskell2010
+  main-is:  msgqueue.hs
+  build-depends:  base >= 4,
+                  zeromq4-haskell  >= 0.1
+executable rrworker
+  default-language: Haskell2010
+  main-is:  rrworker.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  zeromq4-haskell  >= 0.1
+
+executable interrupt
+  default-language: Haskell2010
+  main-is:  interrupt.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  unix,
+                  zeromq4-haskell  >= 0.1
+
+executable mtserver
+  default-language: Haskell2010
+  main-is:  mtserver.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  random,
+                  zeromq4-haskell  >= 0.1
+  GHC-Options: -threaded
+
+executable mtrelay
+  default-language: Haskell2010
+  main-is:  mtrelay.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  zeromq4-haskell  >= 0.1
+
+executable syncpub
+  default-language: Haskell2010
+  main-is:  syncpub.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  zeromq4-haskell  >= 0.1
+executable syncsub
+  default-language: Haskell2010
+  main-is:  syncsub.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  zeromq4-haskell  >= 0.1
+
+executable psenvpub
+  default-language: Haskell2010
+  main-is:  psenvpub.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  zeromq4-haskell  >= 0.1
+executable psenvsub
+  default-language: Haskell2010
+  main-is:  psenvsub.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  zeromq4-haskell  >= 0.1
+
+executable rtreq
+  default-language: Haskell2010
+  main-is:  rtreq.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  random,
+                  time,
+                  zeromq4-haskell  >= 0.1
+
+executable rtdealer
+  default-language: Haskell2010
+  main-is:  rtdealer.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  random,
+                  time,
+                  zeromq4-haskell  >= 0.1
+
+executable lbbroker
+  default-language: Haskell2010
+  main-is:  lbbroker.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  zeromq4-haskell  >= 0.1
+  GHC-Options: -threaded
+
+executable asyncsrv
+  default-language: Haskell2010
+  main-is:  asyncsrv.hs
+  build-depends:  base >= 4,
+                  bytestring,
+                  random,
+                  zeromq4-haskell  >= 0.1
+  GHC-Options: -threaded


### PR DESCRIPTION
The examples now work with the latest version of 0MQ, using [zeromq4-haskell](https://hackage.haskell.org/package/zeromq4-haskell).
- All written examples have been checked.
- Comment, description have been added.
- A cabal file has been added to ease setup (some examples require the `-threaded` compilation flag and this is now explicit.
- HLint cleanup
