### PR TITLE
Remove unreachable code

### DIFF
--- a/examples/Clojure/psenvpub.clj
+++ b/examples/Clojure/psenvpub.clj
@@ -17,6 +17,4 @@
       (mq/send publisher "We don't want to see this.\u0000")
       (mq/send publisher "B\u0000" mq/sndmore)
       (mq/send publisher "We would like to see this.\u0000")
-      (Thread/sleep 1000))
-    (.close publisher)
-    (.term ctx)))
+      (Thread/sleep 1000))))


### PR DESCRIPTION
The final forms of this example's code would never be reached and are redundant, hence removal.

With this change, the sample is also more consistent with its related source file: psenvsub.clj
