### PR TITLE
Fixed: Now usable on Windows too

### DIFF
--- a/examples/C/zhelpers.h
+++ b/examples/C/zhelpers.h
@@ -17,9 +17,13 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
-#include <sys/time.h>
-#include <time.h>
-#include <unistd.h>
+
+#if (defined (WIN32))
+#   include <time.h>
+#else
+#   include <sys/time.h>
+#endif
+
 #include <assert.h>
 #include <signal.h>
 
@@ -29,7 +33,7 @@
 #endif
 
 //  Provide random number from 0..(num-1)
-#if (defined (__WINDOWS__))
+#if (defined (WIN32))
 #   define randof(num)  (int) ((float) (num) * rand () / (RAND_MAX + 1.0))
 #else
 #   define randof(num)  (int) ((float) (num) * random () / (RAND_MAX + 1.0))
@@ -78,7 +82,7 @@ s_dump (void *socket)
         int size = zmq_msg_recv (&message, socket, 0);
 
         //  Dump the message as text or binary
-        char *data = zmq_msg_data (&message);
+        char *data = (char*)zmq_msg_data (&message);
         int is_text = 1;
         int char_nbr;
         for (char_nbr = 0; char_nbr < size; char_nbr++)
@@ -120,7 +124,7 @@ s_set_id (void *socket)
 static void
 s_sleep (int msecs)
 {
-#if (defined (__WINDOWS__))
+#if (defined (WIN32))
     Sleep (msecs);
 #else
     struct timespec t;
@@ -134,7 +138,7 @@ s_sleep (int msecs)
 static int64_t
 s_clock (void)
 {
-#if (defined (__WINDOWS__))
+#if (defined (WIN32))
     SYSTEMTIME st;
     GetSystemTime (&st);
     return (int64_t) st.wSecond * 1000 + st.wMilliseconds;
@@ -153,7 +157,7 @@ s_console (const char *format, ...)
 {
     time_t curtime = time (NULL);
     struct tm *loctime = localtime (&curtime);
-    char *formatted = malloc (20);
+    char *formatted = (char*)malloc (20);
     strftime (formatted, 20, "%y-%m-%d %H:%M:%S ", loctime);
     printf ("%s", formatted);
     free (formatted);


### PR DESCRIPTION
Tested with Windows 7, Visual Studio 2013 Express.

Note: NOT tested on another system (I don't know if it still works on Linux)
Note2: What are those **WINDOWS** defines for? They do not work as far as I can tell, so I changed them to WIN32
