### PR TITLE
Correct 'ZMQ::Device.new' wrt. method signature

### DIFF
--- a/examples/Ruby/msgqueue.rb
+++ b/examples/Ruby/msgqueue.rb
@@ -19,4 +19,4 @@ backend = context.socket(ZMQ::DEALER)
 backend.bind('tcp://*:5560')
 
 # Start built-in device
-poller = ZMQ::Device.new(ZMQ::QUEUE,frontend,backend)
+poller = ZMQ::Device.new(frontend,backend)


### PR DESCRIPTION
This method now takes the capture socket (if any)
as the third parameter, not the first.

https://github.com/chuckremes/ffi-rzmq/blob/master/lib/ffi-rzmq/device.rb
