### PR TITLE
Removing worker from the known workers fixed

### DIFF
--- a/examples/Java/mdbroker.java
+++ b/examples/Java/mdbroker.java
@@ -246,7 +246,7 @@ public class mdbroker {
         }
         if (worker.service != null)
             worker.service.waiting.remove(worker);
-        workers.remove(worker);
+        workers.remove(worker.identity);
         worker.address.destroy();
     }
 


### PR DESCRIPTION
The worker wasn't removed properly from the known workers and remains there even after expiration. The map with workers is indexed by the worker's identity, not by the worker itself. The patch fixes it.
