### PR TITLE
Escape double slash inside teletype text section

### DIFF
--- a/chapter1.txt
+++ b/chapter1.txt
@@ -226,7 +226,7 @@ Some points about the publish-subscribe (pub-sub) pattern:
 
 * If you're using TCP and a subscriber is slow, messages will queue up on the publisher. We'll look at how to protect publishers against this using the "high-water mark" later.
 
-* From ZeroMQ v3.x, filtering happens at the publisher side when using a connected protocol ({{tcp://}} or {{ipc://}}). Using the {{epgm://}} protocol, filtering happens at the subscriber side. In ZeroMQ v2.x, all filtering happened at the subscriber side.
+* From ZeroMQ v3.x, filtering happens at the publisher side when using a connected protocol ({{tcp:@<//>@}} or {{ipc:@<//>@}}). Using the {{epgm:@<//>@}} protocol, filtering happens at the subscriber side. In ZeroMQ v2.x, all filtering happened at the subscriber side.
 
 This is how long it takes to receive and filter 10M messages on my laptop, which is an 2011-era Intel i5, decent but nothing special:
 

--- a/chapter2.txt
+++ b/chapter2.txt
@@ -926,8 +926,8 @@ Let's make three threads that signal each other when they are ready[figure]. In 
 This is a classic pattern for multithreading with ZeroMQ:
 
 # Two threads communicate over {{inproc}}, using a shared context.
-# The parent thread creates one socket, binds it to an {{inproc://}} endpoint, and //then// starts the child thread, passing the context to it.
-# The child thread creates the second socket, connects it to that {{inproc://}} endpoint, and //then// signals to the parent thread that it's ready.
+# The parent thread creates one socket, binds it to an {{inproc:@<//>@}} endpoint, and //then// starts the child thread, passing the context to it.
+# The child thread creates the second socket, connects it to that {{inproc:@<//>@}} endpoint, and //then// signals to the parent thread that it's ready.
 
 Note that multithreading code using this pattern is not scalable out to processes. If you use {{inproc}} and socket pairs, you are building a tightly-bound application, i.e., one where your threads are structurally interdependent. Do this when low latency is really vital. The other design pattern is a loosely bound application, where threads have their own context and communicate over {{ipc}} or {{tcp}}. You can easily break loosely bound threads into separate processes.
 

--- a/chapter5.txt
+++ b/chapter5.txt
@@ -215,7 +215,7 @@ The first thing we have to do is break our subscriber into a multithreaded desig
 
 So the subscriber looks something like a queue device. We could use various sockets to connect the subscriber and workers. If we assume one-way traffic and workers that are all identical, we can use PUSH and PULL and delegate all the routing work to ZeroMQ[figure]. This is the simplest and fastest approach.
 
-The subscriber talks to the publisher over TCP or PGM. The subscriber talks to its workers, which are all in the same process, over {{inproc://}}.
+The subscriber talks to the publisher over TCP or PGM. The subscriber talks to its workers, which are all in the same process, over {{inproc:@<//>@}}.
 
 [[code type="textdiagram" title="Mad Black Box Pattern"]]
                #-----------#
@@ -400,7 +400,7 @@ And here is the client:
 
 Here are some things to note about these two programs:
 
-* The server uses two tasks. One thread produces the updates (randomly) and sends these to the main PUB socket, while the other thread handles state requests on the ROUTER socket. The two communicate across PAIR sockets over an {{inproc://}} connection.
+* The server uses two tasks. One thread produces the updates (randomly) and sends these to the main PUB socket, while the other thread handles state requests on the ROUTER socket. The two communicate across PAIR sockets over an {{inproc:@<//>@}} connection.
 
 * The client is really simple. In C, it consists of about fifty lines of code. A lot of the heavy lifting is done in the {{kvmsg}} class. Even so, the basic Clone pattern is easier to implement than it seemed at first.
 


### PR DESCRIPTION
This prevents interpreting double slash as starting of italic text section and messing the markup outside teletype text section
