### PR TITLE
Adapt rrbroker.hs to use poll, not proxy

### DIFF
--- a/examples/Haskell/rrbroker.hs
+++ b/examples/Haskell/rrbroker.hs
@@ -1,13 +1,22 @@
+-- |
+-- Simple message queuing broker
+--
+-- Use it with `rrclient.hs` and `rrworker.hs`//
 module Main where
 
 import System.ZMQ4.Monadic
+import Control.Monad (forever)
+import qualified Data.List.NonEmpty as NE -- from semigroups
 
 main :: IO ()
-main = 
-    runZMQ $ do 
-        frontend <- socket Router
-        bind frontend "tcp://*:5559"
-        backend <- socket Dealer
-        bind backend "tcp://*:5560"
-        
-        proxy frontend backend Nothing
+main = runZMQ $ do
+  frontend <- socket Router
+  bind frontend "tcp://*:5559"
+  backend <- socket Dealer
+  bind backend "tcp://*:5560"
+  forever $ poll (-1) [ Sock frontend [In] (Just $ frontend >|> backend)
+                      , Sock backend [In] (Just $ backend >|> frontend)
+                      ]
+
+(>|>) :: (Receiver r, Sender s) => Socket z r -> Socket z s -> [Event] -> ZMQ z ()
+(>|>) rcv snd _ = receiveMulti rcv >>= sendMulti snd . NE.fromList

--- a/examples/Haskell/zguide.cabal
+++ b/examples/Haskell/zguide.cabal
@@ -118,7 +118,8 @@ executable rrbroker
   main-is:  rrbroker.hs
   build-depends:  base >= 4,
                   bytestring,
-                  zeromq4-haskell  >= 0.1
+                  zeromq4-haskell  >= 0.1,
+                  semigroups
 executable msgqueue
   default-language: Haskell2010
   main-is:  msgqueue.hs


### PR DESCRIPTION
The examples in other languages use 'poll', because 'proxy' is
only introduced in one of the following sections.

I adapted the haskell rrbroker example to use `poll` as well.

Best,
Markus
