### PR TITLE
Make rtdealer.clj similar to rtreq.clj

### DIFF
--- a/examples/Clojure/rtdealer.clj
+++ b/examples/Clojure/rtdealer.clj
@@ -13,40 +13,46 @@
 ;; Isaiah Peng <issaria@gmail.com>
 ;;
 
-(defrecord Worker [name]
+(defrecord Worker [n]
   Runnable
   (run [this]
     (let [ctx (mq/context 1)
-          worker (mq/socket ctx mq/dealer)]
-      (mq/identify worker name)
+          worker (mq/socket ctx mq/dealer)
+          srandom (Random. (System/currentTimeMillis))]
+      (mq/set-id worker n)
       (mq/connect worker "ipc://routing.ipc")
       (loop [total 0]
-        (let [request (mq/recv-str worker)]
-          (if (= "END" request)
-            (println (format "%s received: %d" name total))
-            (recur (inc total))))))))
+        (mq/send-more worker "")
+        (mq/send worker "ready")
+        (let [_ (mq/recv-str worker) ; envelope
+              workload (mq/recv-str worker)]
+          ;; Do some random work
+          (Thread/sleep (+ (.nextInt srandom 1000) 1000))
+          (if (not= "END" workload)
+            (recur (inc total))
+            (println (format "Worker %d processed %d tasks" n total)))))
+      (.close worker)
+      (.term ctx))))
 
+(def worker-nbr 10)
 (defn -main []
   (let [ctx (mq/context 1)
-        client (mq/socket ctx mq/dealer)
+        client (mq/socket ctx mq/router)
         srandom (Random. (System/currentTimeMillis))]
     (mq/bind client "ipc://routing.ipc")
-    (-> "A" Worker. Thread. .start)
-    (-> "B" Worker. Thread. .start)
-    ;; Wait for threads to connect, since otherwise the messages
-    ;; we send won't be routable.
-    (Thread/sleep 1000)
-    ;; Send 10 tasks scattered to A twice as often as B
-    (dotimes [i 10]
-      ;; Send two message parts, first the address...
-      (if (= 0 (.nextInt srandom 3))
-        (mq/send-more client "B")
-        (mq/send-more client "A"))
-      ;; And then the workload
-      (mq/send client "This is the workload"))
-    (mq/send-more client "A")
-    (mq/send client "END")
-    (mq/send-more client "B")
-    (mq/send client "END")
+    (dotimes [i worker-nbr]
+      (-> i Worker. Thread. .start))
+    (dotimes [i (* 10 worker-nbr)]
+      ;; LRU worker is next waiting in queue
+      (let [address (mq/recv-str client) _ (mq/recv client) _ (mq/recv client)]
+        (mq/send-more client address)
+        (mq/send-more client "")
+        (mq/send client "This is the workload")))
+    ;; Now ask mamas to shutdown and report their results
+    (dotimes [i worker-nbr]
+      (let [address (mq/recv-str client) _ (mq/recv client) _ (mq/recv client)]
+        (mq/send-more client address)
+        (mq/send-more client "")
+        (mq/send client "END")))
     (.close client)
     (.term ctx)))


### PR DESCRIPTION
Both the text and the C examples treat rtreq and rtdealer as being identical except for the change from req to dealer sockets. This changes rtdealer to mirror the structure of rtreq.

If you diff it with rtreq.clj, you'll see that the change is quite minimal. I'm not sure why the existing rtdealer diverges so much from rtreq.
