### PR TITLE
spqueue and spworker in clojure

### DIFF
--- a/examples/Clojure/spqueue.clj
+++ b/examples/Clojure/spqueue.clj
@@ -1,0 +1,44 @@
+(ns spqueue
+  (:require [zeromq.zmq :as zmq]
+            [zmsg :refer :all]))
+
+;;
+;;  Simple Pirate broker
+;;  This is identical to load-balancing pattern, with no reliability
+;;  mechanisms. It depends on the client for recovery. Runs forever.
+;;
+
+(def worker-ready "\001")
+
+(defn -main []
+  (let [ctx (zmq/context 1)
+        frontend (doto (zmq/socket ctx :router)
+                   (zmq/bind "tcp://*:5555"))
+        backend (doto (zmq/socket ctx :router)
+                  (zmq/bind "tcp://*:5556"))]
+    (.addShutdownHook (Runtime/getRuntime)
+                      (Thread. (fn []
+                                 (.close frontend)
+                                 (.close backend)
+                                 (.term ctx))))
+    (let [worker-queue (atom clojure.lang.PersistentQueue/EMPTY)]
+      (while true
+        (let [items (zmq/poller ctx)
+              backend-index (zmq/register items backend :pollin)
+              frontend-index (if-not (empty? @worker-queue)
+                               (zmq/register items frontend :pollin))]
+          (zmq/poll items -1)
+          ;; Handle worker activity on background
+          (if (zmq/check-poller items backend-index :pollin)
+            ;; Queue worker address for LRU routing
+            (let [msg (receive-msg backend)
+                  worker-id (msg-id msg)
+                  msg (msg-unwrap msg)]
+              (swap! worker-queue conj worker-id)
+              (if (not= worker-ready (msg-data msg))
+                (send-msg frontend msg))))
+          (if (and frontend-index (zmq/check-poller items frontend-index :pollin))
+            (let [ msg (receive-msg frontend)
+                  worker-id (peek @worker-queue)]
+              (swap! worker-queue pop)
+              (send-msg backend (msg-wrap worker-id msg)))))))))

--- a/examples/Clojure/spworker.clj
+++ b/examples/Clojure/spworker.clj
@@ -1,0 +1,30 @@
+(ns spworker
+  (:require [zeromq.zmq :as zmq]
+            [zmsg :refer :all]))
+
+(def worker-ready "\001")
+
+(defn -main []
+  (let [ctx (zmq/zcontext)
+        identity (format "%04X-%04X" (rand-int 0x10000) (rand-int 0x10000))
+        worker (doto (zmq/socket ctx :req)
+                 (zmq/set-identity (.getBytes identity))
+                 (zmq/connect "tcp://localhost:5556"))]
+    (println (format "I: (%s) worker ready" identity))
+    (zmq/send-str worker worker-ready)
+    (try
+      (doseq [cycles (iterate inc 1)]
+        (let [msg (receive-msg worker)]
+          (cond
+           (and (> cycles 3) (zero? (rand-int 5)))
+           (do (println "I: (%s) simulating a crash" identity)
+               (throw (Exception. "crashing")))
+           (and (> cycles 3) (zero? (rand-int 5)))
+           (do (println (format "I: (%s) simulating CPU overload" identity))
+               (Thread/sleep 3000))
+           :else nil)
+          (println (format "I: (%s) normal reply" identity))
+          (Thread/sleep 1000)
+          (send-msg worker msg)))
+      (catch Exception _ nil))
+    (zmq/destroy ctx)))

--- a/examples/Clojure/zmsg.clj
+++ b/examples/Clojure/zmsg.clj
@@ -1,0 +1,28 @@
+(ns zmsg
+  (:require [zeromq.zmq :as zmq]))
+
+(defn frames->msg [frames]
+  (->> frames
+       (partition-by empty?)
+       (remove (comp empty? first))
+       (map (fn [f] (if (= (count f) 1) (first f) f)))
+       flatten))
+
+(defn msg->frames [msg-frames]
+  (interpose (byte-array 0) msg-frames))
+
+(def msg-id first)
+(def msg-data last)
+(def msg-unwrap rest)
+(def msg-wrap cons)
+(defn msg-replace-data [msg new-data]
+  (concat (butlast msg) [new-data]))
+
+(defn receive-msg [socket]
+  (frames->msg (zmq/receive-all socket)))
+
+(defn send-msg [socket msg]
+  (let [frames (msg->frames msg)]
+    (doseq [frame (butlast frames)]
+      (zmq/send socket frame zmq/send-more))
+    (zmq/send socket (last frames))))


### PR DESCRIPTION
This implements the Basic Reliable Queuing (Simple Pirate Pattern) example in Clojure. Additionally, I've added a `zmsg` namespace that provides a higher-level interface for sending/receiving entire messages.
