### PR TITLE
set id of socket to allow sender to be stored as a std::string in the broker

### DIFF
--- a/examples/C++/mdcliapi.hpp
+++ b/examples/C++/mdcliapi.hpp
@@ -47,6 +47,7 @@ public:
            delete m_client;
        }
        m_client = new zmq::socket_t (*m_context, ZMQ_REQ);
+       s_set_id(*m_client);
        int linger = 0;
        m_client->setsockopt(ZMQ_LINGER, &linger, sizeof (linger));
        //zmq_setsockopt (client, ZMQ_LINGER, &linger, sizeof (linger));


### PR DESCRIPTION
This fixes the majordomo c++ worker's ability to send the reply back