### PR TITLE
Add support to build example using travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+
+notifications:
+  email: false
+
+script:
+  - ./examples/build all


### PR DESCRIPTION
I think it would be a good idea to include in the travis-ci all the required steps to build the guide. I can't find the docs to build the guide easily...

Also you need to activate travis-ci hook for this repo. It's free :-)