### PR TITLE
remove unused SystemSigner import

### DIFF
--- a/examples/Java/lbbroker2.java
+++ b/examples/Java/lbbroker2.java
@@ -2,7 +2,6 @@ import org.zeromq.*;
 import org.zeromq.ZMQ.Poller;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZThread.IDetachedRunnable;
-import sun.security.provider.SystemSigner;
 
 import java.util.Arrays;
 import java.util.LinkedList;


### PR DESCRIPTION
remove unused SystemSigner import, which can cause cannot find symbol exception when compile use Java8 or Java7