### PR TITLE
Fix: require('tty').setRawMode was removed in Node v6

### DIFF
--- a/examples/Node.js/taskvent.js
+++ b/examples/Node.js/taskvent.js
@@ -4,7 +4,7 @@
 
 var zmq = require('zeromq');
 process.stdin.resume();
-require('tty').setRawMode(true);
+process.stdin.setRawMode(true);
 
 // Socket to send messages on
 var sender = zmq.socket('push');


### PR DESCRIPTION
`require('tty').setRawMode` is deprecated since Node.js `0.10` and was removed in `6.0.0`.

For reference:
https://github.com/zeromq/zeromq.js/issues/123
https://nodejs.org/docs/latest-v5.x/api/tty.html#tty_tty_setrawmode_mode