### PR TITLE
Weather update example julia 0.5.x fixes

### DIFF
--- a/examples/Julia/wuclient.jl
+++ b/examples/Julia/wuclient.jl
@@ -24,12 +24,12 @@ update_nbr = 5
 
 total_temp = 0
 for update in [1:update_nbr]
-    message = bytestring(ZMQ.recv(socket))
+    message = unsafe_string(ZMQ.recv(socket))
     zipcode, temperature, relhumidity = split(message)
-    total_temp += int(temperature)
+    total_temp += parse(temperature)
 end
 
-avg_temp = int(total_temp / update_nbr)
+avg_temp = total_temp / update_nbr
 
 println("Average temperature for zipcode $zip_filter was $(avg_temp)F")
 

--- a/examples/Julia/wuserver.jl
+++ b/examples/Julia/wuserver.jl
@@ -18,6 +18,7 @@ while true
     temperature = rand(-80:135)
     relhumidity = rand(10:60)
     ZMQ.send(socket, "$zipcode $temperature $relhumidity")
+    yield()
 end
 
 ZMQ.close(socket)


### PR DESCRIPTION
Update the weather update pub/sub example in Julia to work correctly with Julia 0.5.x.

- Added a yield() call in the loop of wuserver.jl (see https://github.com/JuliaInterop/ZMQ.jl/issues/148).
- Updated depricated bytestring() and int() functions in wuclient.jl