### PR TITLE
Remove useless for loop

### DIFF
--- a/examples/C/interrupt.c
+++ b/examples/C/interrupt.c
@@ -54,17 +54,15 @@ int main (void)
         perror("Creating self-pipe");
         exit(1);
     }
-    for (int i = 0; i < 2; i++) {
-        int flags = fcntl(pipefds[0], F_GETFL, 0);
-        if (flags < 0) {
-            perror ("fcntl(F_GETFL)");
-            exit(1);
-        }
-        rc = fcntl (pipefds[0], F_SETFL, flags | O_NONBLOCK);
-        if (rc != 0) {
-            perror ("fcntl(F_SETFL)");
-            exit(1);
-        }
+    int flags = fcntl(pipefds[0], F_GETFL, 0);
+    if (flags < 0) {
+        perror ("fcntl(F_GETFL)");
+        exit(1);
+    }
+    rc = fcntl (pipefds[0], F_SETFL, flags | O_NONBLOCK);
+    if (rc != 0) {
+        perror ("fcntl(F_SETFL)");
+        exit(1);
     }
 
     s_catch_signals (pipefds[1]);


### PR DESCRIPTION
The original example created a for loop to set pipefds[0] twice
which is unnecessary.