### PR TITLE
Refactor deprecated ZMQ_NOBLOCK to ZMQ_DONTWAIT

### DIFF
--- a/examples/C/interrupt.c
+++ b/examples/C/interrupt.c
@@ -94,7 +94,7 @@ int main (void)
         if (items [1].revents & ZMQ_POLLIN) {
             char buffer [255];
             // Use non-blocking so we can continue to check self-pipe via zmq_poll
-            rc = zmq_recv (socket, buffer, 255, ZMQ_NOBLOCK);
+            rc = zmq_recv (socket, buffer, 255, ZMQ_DONTWAIT);
             if (rc < 0) {
                 if (errno == EAGAIN) { continue; }
                 if (errno == EINTR) { continue; }


### PR DESCRIPTION
`ZMQ_NOBLOCK` is no longer a documented option and has been marked as an incompatible change since v. 3.2.

Changed to `ZMQ_DONTWAIT` to avoid potential future deprecation / confusion.