### PR TITLE
Problem: Java mentioned in the standalone pages and partially translated

### DIFF
--- a/preface_web.txt
+++ b/preface_web.txt
@@ -7,7 +7,7 @@
 
 Please use the [$(GIT)/issues issue tracker] for all comments and errata. This version covers the latest stable release of ZeroMQ (3.2). If you are using older versions of ZeroMQ then some of the examples and explanations won't be accurate.
 
-The Guide is originally [/page:all in C], but also in [/php:all PHP], [/java:all Java], [/py:all Python], [/lua:all Lua], and [/hx:all Haxe]. We've also translated most of the examples into C++, C#, CL, Delphi, Erlang, F#, Felix, Haskell, Java, Objective-C, Ruby, Ada, Basic, Clojure, Go, Haxe, Node.js, ooc, Perl, and Scala.
+The Guide is originally [/page:all in C], but also in [/php:all PHP], [/java:all Java], [/py:all Python], [/lua:all Lua], and [/hx:all Haxe]. We've also translated most of the examples into C++, C#, CL, Delphi, Erlang, F#, Felix, Haskell, Objective-C, Ruby, Ada, Basic, Clojure, Go, Haxe, Node.js, ooc, Perl, and Scala.
 
 + Preface
 


### PR DESCRIPTION
Solution: As Java examples are complete now remove java from partially translated language list