### PR TITLE
Fix bug: 'Address alredy in use' Exception on files 'examples/C#/peering1.cs' and 'examples/C#/peering2.cs' 

### DIFF
--- a/examples/C#/peering1.cs
+++ b/examples/C#/peering1.cs
@@ -95,7 +95,7 @@ namespace Examples
 
 		static Int16 Peering1_GetPort(string name)
 		{
-			var hash = (Int16)name[0];
+			var hash = (Int16)name.GetHashCode();
 			if (hash < 1024)
 			{
 				hash += 1024;

--- a/examples/C#/peering2.cs
+++ b/examples/C#/peering2.cs
@@ -333,7 +333,7 @@ namespace Examples
 
 		static Int16 Peering2_GetPort(string name) 
 		{
-			var hash = (Int16)name[0];
+			var hash = (Int16)name.GetHashCode();
 			if (hash < 1024)
 			{
 				hash += 1024;


### PR DESCRIPTION
Example throws `Unhandled exception: ZeroMQ.ZException: EADDRINUSE(100): Address in use` on execution time as Peering1_GetPort is not calculating port number properly.