### PR TITLE
Add "Hello World" example for "REQ-ROUTER" mode

### DIFF
--- a/examples/C/hwclient3.c
+++ b/examples/C/hwclient3.c
@@ -1,0 +1,31 @@
+/*
+Hello World client
+REQ socket connect to tcp://localhost:5555
+send "Hello" to Server，expect receive "World" from Server
+*/
+#include "zhelpers.h"
+#include <unistd.h>
+
+int main (void)
+{
+    printf ("Connecting to hello world server...\n");
+    void *context = zmq_ctx_new ();
+    void *requester = zmq_socket (context, ZMQ_REQ);
+    //set REQ socket identity
+    zmq_setsockopt(requester, ZMQ_IDENTITY, "ZMQ", strlen("ZMQ"));
+    zmq_connect (requester, "tcp://localhost:5555");
+    int request_nbr;
+    for (request_nbr = 0; request_nbr < 10; request_nbr++)
+	{
+        char buffer [10]={0};
+		//send request msg
+        printf ("Sending request msg: Hello NO=%d...\n", request_nbr+1);
+        zmq_send (requester, "Hello", 5, 0);
+		//receive respond msg
+        zmq_recv (requester, buffer, 10, 0);
+        printf ("Received respond msg: %s NO=%d\n\n", buffer,request_nbr+1);
+    }
+    zmq_close(requester);
+    zmq_ctx_destroy (context);
+    return 0;
+}

--- a/examples/C/hwserver3.c
+++ b/examples/C/hwserver3.c
@@ -1,0 +1,50 @@
+/*
+Hello World server
+ROUTER socket bind to "tcp://*:5555"
+expect receive "Hello", use "World" reply
+*/
+#include "zhelpers.h"
+#include <unistd.h>
+
+int main (void)
+{
+    void *context = zmq_ctx_new ();
+    void *responder = zmq_socket (context, ZMQ_ROUTER);
+    int rc = zmq_bind (responder, "tcp://*:5555");
+    assert (rc == 0);
+
+    while (1)
+	{
+        char *identity, *string, *content;
+        //receive client request msg
+        identity=s_recv(responder);  //receive the first part is identity frame
+        printf("[Frame_1] identity = %s\n",identity);
+        //if the second part is empty frame, then continue receiving the third part
+        string = s_recv(responder);
+        printf("[Frame_2] string = %s\n", string);
+        if(strcmp(string,"") == 0){
+            //receive the third part is the data frame
+            content = s_recv(responder);
+            printf("[Frame_3] Received request msg: %s\n", content);
+            free(string);
+            free(content);
+        }
+        //if the second part is not empty frame,then discard the whole ZMQ msg.
+        else{
+            printf("Discard the ZMQ message!\n");
+            free(string);
+            free(identity);
+            continue;
+        }
+        sleep (1);   //Do some work
+        //send reply msg to client
+        printf("Send respond msg: World\n\n");
+        s_sendmore(responder,identity);  //send identity frame
+        s_sendmore(responder,"");  //send empty frame
+        zmq_send (responder, "World", 5, 0);  //send data frame
+        free(identity);
+    }
+    zmq_close(responder);
+    zmq_ctx_destroy(context);
+    return 0;
+}


### PR DESCRIPTION
Based in the original "Hello World" example, I use the "REQ-ROUTER" mode to overwrite the example. The two files name are hwclient3.c and hwserver3.c, and I have tested it.