### PR TITLE
Fix a bug that lead to REQ repeated chunk.

### DIFF
--- a/examples/Python/fileio3.py
+++ b/examples/Python/fileio3.py
@@ -30,7 +30,7 @@ def client_thread(ctx, pipe):
             # ask for next chunk
             dealer.send_multipart([
                 b"fetch",
-                b"%i" % total,
+                b"%i" % offset,
                 b"%i" % CHUNK_SIZE,
             ])
 


### PR DESCRIPTION
The second frame of request message should be 'offset' rather than 'total', that makes the client request the first chunk repeatedly until they receive the first chunk from the server.