### PR TITLE
Structure the Java code base, Organize the examples, Migrate to Jdk 1.8 if possible

### DIFF
--- a/examples/Java/src/main/java/com/imatix/zguide/commons/ZConstants.java
+++ b/examples/Java/src/main/java/com/imatix/zguide/commons/ZConstants.java
@@ -11,6 +11,10 @@ public class ZConstants {
     public static class URL {
 
         public static final String TCP = "tcp://*:5555";
+        public static final String TCP_5556 = "tcp://localhost:5556";
+        public static final String TCP_5557 = "tcp://localhost:5557";
+        public static final String TCP_5558 = "tcp://localhost:5558";
         public static final String INPROC = "inproc://%s";
+        public static final String IPC_WEATHER = "ipc://weather";
     }
 }

--- a/examples/Java/src/main/java/com/imatix/zguide/commons/ZConstants.java
+++ b/examples/Java/src/main/java/com/imatix/zguide/commons/ZConstants.java
@@ -11,5 +11,6 @@ public class ZConstants {
     public static class URL {
 
         public static final String TCP = "tcp://*:5555";
+        public static final String INPROC = "inproc://%s";
     }
 }

--- a/examples/Java/src/main/java/com/imatix/zguide/commons/ZHelper.java
+++ b/examples/Java/src/main/java/com/imatix/zguide/commons/ZHelper.java
@@ -1,0 +1,58 @@
+package com.imatix.zguide.commons;
+
+import org.zeromq.ZMQ.Context;
+import org.zeromq.ZMQ.Socket;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import static com.imatix.zguide.commons.ZConstants.URL.INPROC;
+import static java.lang.String.format;
+import static org.zeromq.ZMQ.PAIR;
+
+
+public class ZHelper {
+
+    private static Random RAND = new Random(System.currentTimeMillis());
+
+    /**
+     * Receives all message parts from socket, prints neatly
+     */
+
+    public static void dump(Socket socket) {
+        System.out.println("===============================================");
+        while (true) {
+            byte[] msg = socket.recv(0);
+            StringBuffer stringBuffer = new StringBuffer();
+            IntStream.range(0, msg.length)
+            .filter(i -> msg[i] > 32 || msg[i] < 127)
+            .forEach(j -> stringBuffer.append(format("%02X", msg[j])));
+            String data = stringBuffer.toString();
+            System.out.println(format("[%03d] %s", msg.length, data));
+            if (!socket.hasReceiveMore())
+                break;
+        }
+    }
+
+    static void setId(Socket socket) {
+        socket.setIdentity(format("%04X-%04X", RAND.nextInt(), RAND.nextInt()).getBytes());
+    }
+
+    static List<Socket> buildZPipe(Context context) {
+        Socket socket1 = context.socket(PAIR);
+        socket1.setLinger(0);
+        socket1.setHWM(1);
+
+        Socket socket2 = context.socket(PAIR);
+        socket2.setLinger(0);
+        socket2.setHWM(1);
+
+        String iface = format(INPROC, new BigInteger(130, RAND).toString(32));
+        socket1.bind(iface);
+        socket2.connect(iface);
+        return Arrays.asList(socket1, socket2);
+    }
+}

--- a/examples/Java/src/main/java/com/imatix/zguide/commons/ZHelper.java
+++ b/examples/Java/src/main/java/com/imatix/zguide/commons/ZHelper.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import static com.imatix.zguide.commons.ZConstants.URL.INPROC;
 import static java.lang.String.format;
 import static org.zeromq.ZMQ.PAIR;
 
@@ -50,7 +49,7 @@ public class ZHelper {
         socket2.setLinger(0);
         socket2.setHWM(1);
 
-        String iface = format(INPROC, new BigInteger(130, RAND).toString(32));
+        String iface = String.format(ZConstants.URL.INPROC, new BigInteger(130, RAND).toString(32));
         socket1.bind(iface);
         socket2.connect(iface);
         return Arrays.asList(socket1, socket2);

--- a/examples/Java/src/main/java/com/imatix/zguide/ex1_10/TaskSink.java
+++ b/examples/Java/src/main/java/com/imatix/zguide/ex1_10/TaskSink.java
@@ -1,0 +1,46 @@
+package com.imatix.zguide.ex1_10;
+
+import org.zeromq.ZMQ.Context;
+import org.zeromq.ZMQ.Socket;
+
+import static com.imatix.zguide.commons.ZConstants.URL.TCP_5558;
+import static java.lang.System.currentTimeMillis;
+import static org.zeromq.ZMQ.PULL;
+import static org.zeromq.ZMQ.context;
+
+/**
+ * Task sink in Java
+ * Binds PULL socket to tcp://localhost:5558
+ * Collects results from workers via that socket
+ *
+ * @since 1.0
+ */
+
+public class TaskSink {
+
+    public static void main(String[] args) {
+        //  Prepare our context and socket
+        Context context = context(1);
+        Socket receiver = context.socket(PULL);
+        receiver.bind(TCP_5558);
+        //  Wait for start of batch
+        String message = new String(receiver.recv(0));
+        System.out.println("Start of the batch: " + message);
+        //  Start our clock now
+        long start = currentTimeMillis();
+        //  Process 100 confirmations
+        int taskNum;
+        for (taskNum = 0; taskNum < 100; taskNum++) {
+            new String(receiver.recv(0));
+            if ((taskNum / 10) * 10 == taskNum)
+                System.out.println(":");
+            else
+                System.out.println(".");
+        }
+        //  Calculate and report duration of batch
+        long end = currentTimeMillis();
+        System.out.printf("\nTotal elapsed time: %d msec.", (end - start));
+        receiver.close();
+        context.term();
+    }
+}

--- a/examples/Java/src/main/java/com/imatix/zguide/ex1_4/HwClient.java
+++ b/examples/Java/src/main/java/com/imatix/zguide/ex1_4/HwClient.java
@@ -1,4 +1,4 @@
-package com.imatix.zguide.ex1_1;
+package com.imatix.zguide.ex1_4;
 
 import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;

--- a/examples/Java/src/main/java/com/imatix/zguide/ex1_4/HwClient.java
+++ b/examples/Java/src/main/java/com/imatix/zguide/ex1_4/HwClient.java
@@ -3,7 +3,6 @@ package com.imatix.zguide.ex1_4;
 import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;
 
-import java.util.Arrays;
 import java.util.stream.IntStream;
 
 import static com.imatix.zguide.commons.ZConstants.URL.TCP;
@@ -27,12 +26,12 @@ public class HwClient {
         Socket requester = context.socket(REQ);
         requester.connect(TCP);
         IntStream.range(0, 10)
-                .forEach(reqNum -> {
-                    System.out.println(format("Sending Hello %s", reqNum));
-                    requester.send("Hello".getBytes(), 0);
-                    byte[] reply = requester.recv(0);
-                    System.out.println(format("Received %s : %s", Arrays.toString(reply), reqNum));
-                });
+        .forEach(reqNum -> {
+            System.out.println(format("Sending Hello %s", reqNum));
+            requester.send("Hello".getBytes(), 0);
+            byte[] reply = requester.recv(0);
+            System.out.println(format("Received %s : %s", new String(reply), reqNum));
+        });
         requester.close();
         context.term();
     }

--- a/examples/Java/src/main/java/com/imatix/zguide/ex1_5/Version.java
+++ b/examples/Java/src/main/java/com/imatix/zguide/ex1_5/Version.java
@@ -1,0 +1,20 @@
+package com.imatix.zguide.ex1_5;
+
+import static java.lang.String.format;
+import static org.zeromq.ZMQ.getFullVersion;
+import static org.zeromq.ZMQ.getVersionString;
+
+/**
+ * Report 0MQ version
+ *
+ * @since 1.0
+ */
+
+public class Version {
+
+    public static void main(String[] args) {
+        System.out.println(format("Version String: %s & Version int: %d",
+                getVersionString(),
+                getFullVersion()));
+    }
+}

--- a/examples/Java/src/main/java/com/imatix/zguide/ex1_6/WuServer.java
+++ b/examples/Java/src/main/java/com/imatix/zguide/ex1_6/WuServer.java
@@ -1,0 +1,49 @@
+package com.imatix.zguide.ex1_6;
+
+import org.zeromq.ZMQ.Context;
+import org.zeromq.ZMQ.Socket;
+
+import java.util.Random;
+
+import static com.imatix.zguide.commons.ZConstants.URL.IPC_WEATHER;
+import static com.imatix.zguide.commons.ZConstants.URL.TCP_5556;
+import static java.lang.String.format;
+import static java.lang.System.currentTimeMillis;
+import static java.lang.Thread.currentThread;
+import static org.zeromq.ZMQ.PUB;
+import static org.zeromq.ZMQ.context;
+
+/**
+ * Weather update server in Java
+ * Binds PUB socket to tcp://*:5556
+ * Publishes random weather updates
+ *
+ * @since 1.0
+ */
+
+public class WuServer {
+
+
+    public static void main(String[] args) {
+        //  Prepare our context and publisher
+        Context context = context(1);
+        Socket publisher = context.socket(PUB);
+        publisher.bind(TCP_5556);
+        publisher.bind(IPC_WEATHER);
+        while (!currentThread().isInterrupted())
+            publisher.send(prepareWeatherUpdate(), 0);
+        publisher.close();
+        context.term();
+    }
+
+    private static String prepareWeatherUpdate() {
+        Random random = new Random(currentTimeMillis());
+        //  Get values that will fool the boss
+        int zipCode, temperature, relHumidity;
+        zipCode = 10000 + random.nextInt(10000);
+        temperature = random.nextInt(215) - 80 + 1;
+        relHumidity = random.nextInt(50) + 10 + 1;
+        //  Send message to all subscribers
+        return format("%05d %d %d", zipCode, temperature, relHumidity);
+    }
+}

--- a/examples/Java/src/main/java/com/imatix/zguide/ex1_7/WuClient.java
+++ b/examples/Java/src/main/java/com/imatix/zguide/ex1_7/WuClient.java
@@ -1,0 +1,51 @@
+package com.imatix.zguide.ex1_7;
+
+import com.imatix.zguide.commons.ZConstants;
+import org.zeromq.ZMQ.Context;
+import org.zeromq.ZMQ.Socket;
+
+import java.util.StringTokenizer;
+
+import static java.lang.String.format;
+import static org.zeromq.ZMQ.SUB;
+import static org.zeromq.ZMQ.context;
+
+/**
+ * Weather update client in Java
+ * Connects SUB socket to tcp://localhost:5556
+ * Collects weather updates and finds avg temp in zipcode
+ *
+ * @since 1.0
+ */
+
+public class WuClient {
+
+    public static void main(String[] args) {
+        Context context = context(1);
+        System.out.println("Collecting updates from weather update server...");
+        //  Socket to talk to server
+        Socket subscriber = context.socket(SUB);
+        subscriber.connect(ZConstants.URL.TCP_5556);
+        //  Subscribe to zipCode, default is NYC, 10001
+        String filter = (args.length > 0) ? args[0] : "10001";
+        subscriber.subscribe(filter.getBytes());
+        // Process 100 updates
+        long totalTemp = 0;
+        int updateNum = 0;
+        while (updateNum < 100) {
+            //  Use trim to remove the tailing '0' character
+            String receivedStr = subscriber.recvStr(0).trim();
+            StringTokenizer tokenizer = new StringTokenizer(receivedStr, " ");
+            int zipCode = Integer.valueOf(tokenizer.nextToken());
+            int temperature = Integer.valueOf(tokenizer.nextToken());
+            int relHumidity = Integer.valueOf(tokenizer.nextToken());
+            System.out.println(format("Weather update: zipCode: %d , temperature: %d , humidity: %d",
+                    zipCode, temperature, relHumidity));
+            totalTemp += temperature;
+            updateNum++;
+        }
+        System.out.printf("Average Temperature for zipCode %s was %d", filter, (int) (totalTemp / updateNum));
+        subscriber.close();
+        context.term();
+    }
+}

--- a/examples/Java/src/main/java/com/imatix/zguide/ex1_8/TaskVent.java
+++ b/examples/Java/src/main/java/com/imatix/zguide/ex1_8/TaskVent.java
@@ -1,0 +1,60 @@
+package com.imatix.zguide.ex1_8;
+
+import org.zeromq.ZMQ.Context;
+import org.zeromq.ZMQ.Socket;
+
+import java.io.IOException;
+import java.util.Random;
+
+import static com.imatix.zguide.commons.ZConstants.URL.TCP_5557;
+import static com.imatix.zguide.commons.ZConstants.URL.TCP_5558;
+import static java.lang.String.format;
+import static org.zeromq.ZMQ.PUSH;
+import static org.zeromq.ZMQ.context;
+
+/**
+ * Task ventilator in Java
+ * Binds PUSH socket to tcp://localhost:5557
+ * Sends batch of tasks to workers via that socket
+ *
+ * @since 1.0
+ */
+
+public class TaskVent {
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        Context context = context(1);
+
+        //  Socket to send messages on
+        Socket sender = context.socket(PUSH);
+        sender.bind(TCP_5557);
+        //  Socket to send messages on
+        Socket sink = context.socket(PUSH);
+        sink.connect(TCP_5558); // Why connect ?
+        System.out.println("Press Enter as soon as the workers are all set: ");
+        System.in.read();
+        System.out.println("Sending Tasks to the workers ...");
+        //  The first message is "0" and signals start of batch
+        sink.send("0", 0);
+        //  Initialize random number generator
+        Random random = new Random(System.currentTimeMillis());
+        //  Send 100 tasks
+        int totalDuration = 0;
+        for (int taskNum = 0; taskNum < 100; taskNum++) {
+            int workload;
+            //  Random workload from 1 to 100 msecs.
+            workload = random.nextInt(100) + 1;
+            totalDuration += workload;
+            System.out.println(workload + ".");
+            String taskDuration = format("%d", workload);
+            sender.send(taskDuration, 0);
+        }
+
+        System.out.printf("\nTotal expected cost: %d msec.", totalDuration);
+        //  Give 0MQ time to deliver
+        Thread.sleep(1000);
+        sink.close();
+        sender.close();
+        context.term();
+    }
+}

--- a/examples/Java/src/main/java/com/imatix/zguide/ex1_9/TaskWork.java
+++ b/examples/Java/src/main/java/com/imatix/zguide/ex1_9/TaskWork.java
@@ -1,0 +1,47 @@
+package com.imatix.zguide.ex1_9;
+
+import org.zeromq.ZMQ.*;
+
+import static com.imatix.zguide.commons.ZConstants.URL.TCP_5557;
+import static com.imatix.zguide.commons.ZConstants.URL.TCP_5558;
+import static org.zeromq.ZMQ.*;
+
+/**
+ * Task worker in Java
+ * Connects PULL socket to tcp://localhost:5557
+ * Collects workloads from ventilator via that socket
+ * Connects PUSH socket to tcp://localhost:5558
+ * Sends results to sink via that socket
+ *
+ * @since 1.0
+ */
+
+public class TaskWork {
+
+    public static void main(String[] args) throws InterruptedException {
+
+        Context context = context(1);
+        //  Socket to receive messages on
+        Socket receiver = context.socket(PULL);
+        receiver.connect(TCP_5557);
+        //  Socket to send messages to
+        Socket sender = context.socket(PUSH);
+        sender.connect(TCP_5558);
+        //  Process tasks forever
+        while (!Thread.currentThread().isInterrupted()) {
+            String duration = new String(receiver.recv(0)).trim();
+            long msec = Long.parseLong(duration);
+            //  Simple progress indicator for the viewer
+            System.out.flush();
+            System.out.println(duration + " . ");
+            //  Do the work
+            Thread.sleep(msec);
+            //  Send results to sink
+            sender.send("".getBytes(), 0);
+        }
+        sender.close();
+        receiver.close();
+        context.term();
+    }
+
+}


### PR DESCRIPTION
Hi, 
That would be more organized and clean if any example code be located in a directory with the example number. Also, the structure of the examples was not standard as a Java project, having main and test root package, etc. 
Please have a quick look at the code, if you find it acceptable I would gradually migrate the rest.

Best,
- Ali  