### PR TITLE
espresso.py subscriber should only get 5 messages.

### DIFF
--- a/examples/Python/espresso.py
+++ b/examples/Python/espresso.py
@@ -26,7 +26,7 @@ def subscriber_thread():
     subscriber.setsockopt(zmq.SUBSCRIBE, b"B")
 
     count = 0
-    while True:
+    while count < 5:
         try:
             msg = subscriber.recv_multipart()
         except zmq.ZMQError as e:


### PR DESCRIPTION
As in espresso.c, the subscriber thread in espresso.py should only get 5 messages, so as to demonstrate both subscribing and unsubscribing.