### PR TITLE
Add syncsub/pub example for Rust

### DIFF
--- a/examples/Rust/syncpub.rs
+++ b/examples/Rust/syncpub.rs
@@ -1,0 +1,30 @@
+extern crate zmq;
+
+fn main() {
+    const SUBSCRIBERS_EXPECTED: usize = 10;
+    let context = zmq::Context::new();
+
+    // socket that talks to clients
+    let publisher = context.socket(zmq::PUB).unwrap();
+    // Set the high-water mark to 10k messages
+    assert!(publisher.set_sndhwm(1_000_100).is_ok());
+    publisher.bind("tcp://*:5562").unwrap();
+
+    // socket that receives messages
+    let sync_service = context.socket(zmq::REP).unwrap();
+    sync_service.bind("tcp://*:5561").unwrap();
+
+    println!("Waiting for subscribers");
+    let mut num_subscribers = 0;
+    while num_subscribers < SUBSCRIBERS_EXPECTED {
+        let _ = sync_service.recv_string(0).unwrap().unwrap();
+        assert!(sync_service.send_str("", 0).is_ok());
+        num_subscribers += 1;
+    }
+    //  Now broadcast exactly 1M updates followed by END
+    println!("Broadcasting messages");
+    for _ in 0..1_000_000 {
+        assert!(publisher.send_str("Rhubarb", 0).is_ok());
+    }
+    assert!(publisher.send_str("END", 0).is_ok());
+}

--- a/examples/Rust/syncsub.rs
+++ b/examples/Rust/syncsub.rs
@@ -1,0 +1,31 @@
+extern crate zmq;
+
+fn main() {
+    let context = zmq::Context::new();
+
+    let subscriber = context.socket(zmq::SUB).unwrap();
+    assert!(subscriber.connect("tcp://localhost:5562").is_ok());
+    assert!(subscriber.set_subscribe(b"").is_ok());
+    // socket that receives messages
+    let sync_client = context.socket(zmq::REQ).unwrap();
+    sync_client.connect("tcp://localhost:5561").unwrap();
+
+    assert!(sync_client.send_str("", 0).is_ok());
+
+    // wait for synchronization reply
+    let _ = sync_client.recv_string(0).unwrap().unwrap();
+
+    // Get our updates and report how many we got
+    let mut n = 0;
+    let mut done = false;
+    while !done {
+        let msg = subscriber.recv_string(0).unwrap().unwrap_or("".to_string());
+        if msg == "Rhubarb" {
+            n += 1;
+        } else {
+            done = msg == "END";
+        }
+    }
+    println!("Received {} updates", n);
+
+}

--- a/examples/Rust/syncsub.rs
+++ b/examples/Rust/syncsub.rs
@@ -1,11 +1,17 @@
 extern crate zmq;
 
+use std::thread;
+use std::time::Duration;
+
 fn main() {
     let context = zmq::Context::new();
 
     let subscriber = context.socket(zmq::SUB).unwrap();
     assert!(subscriber.connect("tcp://localhost:5562").is_ok());
     assert!(subscriber.set_subscribe(b"").is_ok());
+
+    thread::sleep(Duration::from_secs(1));
+
     // socket that receives messages
     let sync_client = context.socket(zmq::REQ).unwrap();
     sync_client.connect("tcp://localhost:5561").unwrap();

--- a/examples/Rust/syncsub.sh
+++ b/examples/Rust/syncsub.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+echo "Starting publisher..."
+./target/release/syncpub &
+sleep 1
+echo "Starting subscribers..."
+for ((a=0; a<10; a++)); do
+    ./target/release/syncsub &
+done
+wait

--- a/examples/Rust/syncsub.sh
+++ b/examples/Rust/syncsub.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 echo "Starting publisher..."
 ./target/release/syncpub &
-sleep 1
 echo "Starting subscribers..."
 for ((a=0; a<10; a++)); do
     ./target/release/syncsub &


### PR DESCRIPTION
Adds the syncpub / syncsub example for rust.

Output from the script is:
```text
Starting publisher...
Waiting for subscribers
Starting subscribers...
Broadcasting messages
Received 1000000 updates
Received 1000000 updates
Received 1000000 updates
Received 1000000 updates
Received 1000000 updates
Received 1000000 updates
Received 1000000 updates
Received 1000000 updates
Received 1000000 updates
Received 1000000 updates
```