### PR TITLE
Update for ocaml-zmq 5.0

### DIFF
--- a/examples/OCaml/build
+++ b/examples/OCaml/build
@@ -3,7 +3,7 @@
 #   Examples build helper
 #   Syntax: build all | clean
 
-OCAMLBUILD="ocamlbuild -j 0 -use-ocamlfind -tag package(ZMQ),debug,annot"
+OCAMLBUILD="ocamlbuild -j 0 -use-ocamlfind -tag package(zmq),debug,annot"
 
 if [ /$1/ = /all/ ]; then
     echo "Building all examples... $(echo *.ml | sed s/\.ml//g)"

--- a/examples/OCaml/helpers.ml
+++ b/examples/OCaml/helpers.ml
@@ -1,5 +1,5 @@
 
-open ZMQ
+open Zmq
 
 let (@@) f x = f x
 let (|>) x f = f x

--- a/examples/OCaml/hwclient.ml
+++ b/examples/OCaml/hwclient.ml
@@ -1,6 +1,6 @@
 (** Hello World client *)
 
-open ZMQ
+open Zmq
 open Helpers
 
 let () =

--- a/examples/OCaml/hwserver.ml
+++ b/examples/OCaml/hwserver.ml
@@ -1,6 +1,6 @@
 (** Hello World server *)
 
-open ZMQ
+open Zmq
 open Helpers
 
 let () =

--- a/examples/OCaml/rrbroker.ml
+++ b/examples/OCaml/rrbroker.ml
@@ -1,6 +1,6 @@
 (* Simple request-reply broker *)
 
-open ZMQ
+open Zmq
 open Helpers
 
 let () =

--- a/examples/OCaml/rrclient.ml
+++ b/examples/OCaml/rrclient.ml
@@ -3,7 +3,7 @@
  * Connects REQ socket to tcp://localhost:5559
  * Sends "Hello" to server, expects "World" back
  *)
-open ZMQ
+open Zmq
 open Helpers
 
 let () =

--- a/examples/OCaml/rrworker.ml
+++ b/examples/OCaml/rrworker.ml
@@ -3,7 +3,7 @@
  * Connects REP socket to tcp://*:5560
  * Expects "Hello" from client, replies with "World"
  *)
-open ZMQ
+open Zmq
 open Helpers
 
 let () =

--- a/examples/OCaml/tasksink.ml
+++ b/examples/OCaml/tasksink.ml
@@ -4,7 +4,7 @@
   Collects results from workers via that socket
 *)
 
-open ZMQ
+open Zmq
 open Helpers
 
 let () =

--- a/examples/OCaml/tasksink2.ml
+++ b/examples/OCaml/tasksink2.ml
@@ -2,7 +2,7 @@
  * Task sink - design 2
  * Adds pub-sub flow to send kill signal to workers
  *)
-open ZMQ
+open Zmq
 open Helpers
 
 let () =

--- a/examples/OCaml/taskvent.ml
+++ b/examples/OCaml/taskvent.ml
@@ -4,7 +4,7 @@
   Sends batch of tasks to workers via that socket
 *)
 
-open ZMQ
+open Zmq
 open Helpers
 
 let () =

--- a/examples/OCaml/taskwork.ml
+++ b/examples/OCaml/taskwork.ml
@@ -6,7 +6,7 @@
   Sends results to sink via that socket
 *)
 
-open ZMQ
+open Zmq
 open Helpers
 
 let () =

--- a/examples/OCaml/taskwork2.ml
+++ b/examples/OCaml/taskwork2.ml
@@ -2,7 +2,7 @@
  * Task worker - design 2
  * Adds pub-sub flow to receive and respond to kill signal
  *)
-open ZMQ
+open Zmq
 open Helpers
 
 let () =

--- a/examples/OCaml/version.ml
+++ b/examples/OCaml/version.ml
@@ -3,5 +3,5 @@
 open Helpers
 
 let () =
-  let (major, minor, patch) = ZMQ.version () in
+  let (major, minor, patch) = Zmq.version () in
   printfn "Current 0MQ version is %d.%d.%d" major minor patch

--- a/examples/OCaml/wuclient.ml
+++ b/examples/OCaml/wuclient.ml
@@ -4,7 +4,7 @@
   Collects weather updates and finds avg temp in zipcode
 *)
 
-open ZMQ
+open Zmq
 open Helpers
 
 let () =

--- a/examples/OCaml/wuserver.ml
+++ b/examples/OCaml/wuserver.ml
@@ -4,7 +4,7 @@
   Publishes random weather updates
 *)
 
-open ZMQ
+open Zmq
 open Helpers
 
 let () =


### PR DESCRIPTION
ZMQ module has been renamed Zmq a few months ago in the OCaml binding. This works with the latest version.