### PR TITLE
Fix memory leak

### DIFF
--- a/examples/C++/mdbroker.cpp
+++ b/examples/C++/mdbroker.cpp
@@ -201,6 +201,7 @@ private:
        msg->wrap(MDPC_CLIENT, service_name.c_str());
        msg->wrap(client.c_str(), "");
        msg->send (*m_socket);
+       delete msg;
    }
 
    //  ---------------------------------------------------------------------


### PR DESCRIPTION
After zmsg* send() ,need delete for release the memory.