### PR TITLE
Fix broken C code in example in Chapter 3

### DIFF
--- a/chapter3.txt
+++ b/chapter3.txt
@@ -497,7 +497,6 @@ while (true) {
 
     char empty [1];
     int empty_size = zmq_recv (worker, empty, 1, 0);
-    zmq_recv (worker, &empty, 0);
     assert (empty_size <= 0);
     if (empty_size == -1)
         break;


### PR DESCRIPTION
The zmq_recv function has incompatible signature, so the original shouldn't compile.

Fixes: https://github.com/booksbyus/zguide/commit/5545672e03f69bed1234ba5bc313079bcff78c16#diff-2157540d85070f458245d027ded1895dR502 ('Cleaned up references to zmq_msg_recv/send')