### PR TITLE
Fixed infinite loop in the server thread

### DIFF
--- a/examples/Python/fileio3.py
+++ b/examples/Python/fileio3.py
@@ -91,6 +91,10 @@ def server_thread(ctx):
 
         # Send resulting chunk to client
         router.send_multipart([identity, data])
+        
+        # Break when all data is read
+        if not data:
+            break
 
 # The main task is just the same as in the first model.
 # .skip


### PR DESCRIPTION
Server did not check for when the data is completely read. It sends the file and continues to loop infinitely.