### PR TITLE
Fix unused warning in c++11

### DIFF
--- a/examples/C++/zhelpers.hpp
+++ b/examples/C++/zhelpers.hpp
@@ -16,7 +16,6 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <signal.h>
-
 #if (!defined(WIN32))
 #   include <sys/time.h>
 #   include <unistd.h>
@@ -71,31 +70,90 @@
 #endif
 
 //  Provide random number from 0..(num-1)
-#define within(num) (int) ((float) (num) * random () / (RAND_MAX + 1.0))
+#define within(num) (int) ((float)((num) * random ()) / (RAND_MAX + 1.0))
+
+//  Receive 0MQ string from socket and convert into C string
+//  Caller must free returned string.
+inline static char *
+s_recv(void *socket, int flags = 0) {
+	zmq_msg_t message;
+	zmq_msg_init(&message);
+
+	int rc = zmq_msg_recv(&message, socket, flags);
+
+	if (rc < 0)
+		return nullptr;           //  Context terminated, exit
+
+	size_t size = zmq_msg_size(&message);
+	char *string = (char*)malloc(size + 1);
+	memcpy(string, zmq_msg_data(&message), size);
+	zmq_msg_close(&message);
+	string[size] = 0;
+	return (string);
+}
 
 //  Receive 0MQ string from socket and convert into string
-static std::string
-s_recv (zmq::socket_t & socket) {
+inline static std::string
+s_recv (zmq::socket_t & socket, int flags = 0) {
 
     zmq::message_t message;
-    socket.recv(&message);
+    socket.recv(&message, flags);
 
     return std::string(static_cast<char*>(message.data()), message.size());
 }
 
+inline static bool s_recv(zmq::socket_t & socket, std::string & ostring, int flags = 0)
+{
+	zmq::message_t message;
+	bool rc = socket.recv(&message, flags);
+
+	if (rc) {
+		ostring = std::string(static_cast<char*>(message.data()), message.size());
+	}
+	
+	return (rc);
+}
+
+//  Convert C string to 0MQ string and send to socket
+inline static int
+s_send(void *socket, const char *string, int flags = 0) {
+	int rc;
+	zmq_msg_t message;
+	zmq_msg_init_size(&message, strlen(string));
+	memcpy(zmq_msg_data(&message), string, strlen(string));
+	rc = zmq_msg_send(&message, socket, flags);
+	assert(-1 != rc);
+	zmq_msg_close(&message);
+	return (rc);
+}
+
 //  Convert string to 0MQ string and send to socket
-static bool
-s_send (zmq::socket_t & socket, const std::string & string) {
+inline static bool
+s_send (zmq::socket_t & socket, const std::string & string, int flags = 0) {
 
     zmq::message_t message(string.size());
     memcpy (message.data(), string.data(), string.size());
 
-    bool rc = socket.send (message);
+    bool rc = socket.send (message, flags);
     return (rc);
 }
 
 //  Sends string as 0MQ string, as multipart non-terminal
-static bool
+inline static int
+s_sendmore(void *socket, char *string) {
+	int rc;
+	zmq_msg_t message;
+	zmq_msg_init_size(&message, strlen(string));
+	memcpy(zmq_msg_data(&message), string, strlen(string));
+	//rc = zmq_send(socket, string, strlen(string), ZMQ_SNDMORE);
+	rc = zmq_msg_send(&message, socket, ZMQ_SNDMORE);
+	assert(-1 != rc);
+	zmq_msg_close(&message);
+	return (rc);
+}
+
+//  Sends string as 0MQ string, as multipart non-terminal
+inline static bool
 s_sendmore (zmq::socket_t & socket, const std::string & string) {
 
     zmq::message_t message(string.size());
@@ -107,7 +165,7 @@ s_sendmore (zmq::socket_t & socket, const std::string & string) {
 
 //  Receives all message parts from socket, prints neatly
 //
-static void
+inline static void
 s_dump (zmq::socket_t & socket)
 {
     std::cout << "----------------------------------------" << std::endl;
@@ -118,12 +176,12 @@ s_dump (zmq::socket_t & socket)
         socket.recv(&message);
 
         //  Dump the message as text or binary
-        int size = message.size();
+        size_t size = message.size();
         std::string data(static_cast<char*>(message.data()), size);
 
         bool is_text = true;
 
-        int char_nbr;
+        size_t char_nbr;
         unsigned char byte;
         for (char_nbr = 0; char_nbr < size; char_nbr++) {
             byte = data [char_nbr];
@@ -179,7 +237,7 @@ s_set_id(zmq::socket_t & socket, intptr_t id)
 
 //  Report 0MQ version number
 //
-static void
+inline static void
 s_version (void)
 {
     int major, minor, patch;
@@ -187,7 +245,7 @@ s_version (void)
     std::cout << "Current 0MQ version is " << major << "." << minor << "." << patch << std::endl;
 }
 
-static void
+inline static void
 s_version_assert (int want_major, int want_minor)
 {
     int major, minor, patch;
@@ -202,7 +260,7 @@ s_version_assert (int want_major, int want_minor)
 }
 
 //  Return current system clock as milliseconds
-static int64_t
+inline static int64_t
 s_clock (void)
 {
 #if (defined (WIN32))
@@ -221,7 +279,7 @@ s_clock (void)
 }
 
 //  Sleep for a number of milliseconds
-static void
+inline static void
 s_sleep (int msecs)
 {
 #if (defined (WIN32))
@@ -234,7 +292,7 @@ s_sleep (int msecs)
 #endif
 }
 
-static void
+inline static void
 s_console (const char *format, ...)
 {
     time_t curtime = time (NULL);
@@ -259,12 +317,12 @@ s_console (const char *format, ...)
 //  zmq_poll.
 
 static int s_interrupted = 0;
-static void s_signal_handler (int signal_value)
+inline static void s_signal_handler (int signal_value)
 {
     s_interrupted = 1;
 }
 
-static void s_catch_signals ()
+inline static void s_catch_signals ()
 {
 #if (!defined(WIN32))
     struct sigaction action;
@@ -275,5 +333,7 @@ static void s_catch_signals ()
     sigaction (SIGTERM, &action, NULL);
 #endif
 }
+
+
 
 #endif


### PR DESCRIPTION
when use c++11, cause a lot of unused funtion warnning.
add inline before static to fix it.

add some overload function for different function call