### PR TITLE
Mark s_interrupted as volatile

### DIFF
--- a/examples/C++/interrupt.cpp
+++ b/examples/C++/interrupt.cpp
@@ -6,7 +6,7 @@
 #include <signal.h>
 #include <zmq.hpp>
 
-static int s_interrupted = 0;
+static volatile int s_interrupted = 0;
 static void s_signal_handler (int signal_value)
 {
     s_interrupted = 1;


### PR DESCRIPTION
Because `s_interrupted` gets modified in the signal handler, which is outside of
normal control flow, it must be marked volatile to ensure the memory address is
always consulted in the `main` while loop. Otherwise the compiler might hoist the
memory access outside of the loop and deduce that the variable is never modified.

For example, the following incorrect program's assembly doesn't even bother
testing the `static int flag`:

https://godbolt.org/z/pkkD9h
```
static int flag;

void zmq_msg_init(void *);
void zmq_msg_close(void *) noexcept;

struct message_t {
    message_t() {
        zmq_msg_init(this);
    }
    ~message_t() {
        zmq_msg_close(this);
    }
};

void incorrect() {
    while (1) {
        message_t msg;
        if (flag) break;
    }
}
```