### PR TITLE
Set both pipefds[0] and pipefds[1] to O_NONBLOCK

### DIFF
--- a/examples/C/interrupt.c
+++ b/examples/C/interrupt.c
@@ -54,15 +54,17 @@ int main (void)
         perror("Creating self-pipe");
         exit(1);
     }
-    int flags = fcntl(pipefds[0], F_GETFL, 0);
-    if (flags < 0) {
-        perror ("fcntl(F_GETFL)");
-        exit(1);
-    }
-    rc = fcntl (pipefds[0], F_SETFL, flags | O_NONBLOCK);
-    if (rc != 0) {
-        perror ("fcntl(F_SETFL)");
-        exit(1);
+    for (int i = 0; i < 2; i++) {
+        int flags = fcntl(pipefds[i], F_GETFL, 0);
+        if (flags < 0) {
+            perror ("fcntl(F_GETFL)");
+            exit(1);
+        }
+        rc = fcntl (pipefds[i], F_SETFL, flags | O_NONBLOCK);
+        if (rc != 0) {
+            perror ("fcntl(F_SETFL)");
+            exit(1);
+        }
     }
 
     s_catch_signals (pipefds[1]);


### PR DESCRIPTION
(Recreating PR from branch rather than master)

It is important to set both ends of the self pipe as nonblocking, otherwise
the signal handler might block on the `write` call  and the process will deadlock.
Example:
```
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
  * frame #0: 0x00007fff5f09ff46 libsystem_kernel.dylib`write + 10
    frame #1: 0x000000010f8f9cd2 interrupt`s_signal_handler(signal_value=2) at interrupt.c:20:12
    frame #2: 0x00007fff5f152b5d libsystem_platform.dylib`_sigtramp + 29
    frame #3: 0x000000010f8f981a interrupt`burn_cpu at interrupt.c:44:3
    frame #4: 0x000000010f8f9b60 interrupt`main at interrupt.c:114:23
    frame #5: 0x00007fff5ef673d5 libdyld.dylib`start + 1
    frame #6: 0x00007fff5ef673d5 libdyld.dylib`start + 1
(lldb) f 1
frame #1: 0x000000010f8f9cd2 interrupt`s_signal_handler(signal_value=2) at interrupt.c:20:12
   17  	#define S_ERROR_MSG "Error while writing to self-pipe.\n"
   18  	static int s_fd;
   19  	static void s_signal_handler(int signal_value) {
-> 20  	  int rc = write(s_fd, S_NOTIFY_MSG, sizeof(S_NOTIFY_MSG));
   21  	  if (rc != sizeof(S_NOTIFY_MSG)) {
   22  	    write(STDOUT_FILENO, S_ERROR_MSG, sizeof(S_ERROR_MSG) - 1);
   23  	    perror("error writing\n");
```

Original code was buggy, as it did not use the loop variable `i`:
```
    for (int i = 0; i < 2; i++) {
        int flags = fcntl(pipefds[0], F_GETFL, 0);
        if (flags < 0) {
            perror ("fcntl(F_GETFL)");
            exit(1);
        }
        rc = fcntl (pipefds[0], F_SETFL, flags | O_NONBLOCK);
        if (rc != 0) {
            perror ("fcntl(F_SETFL)");
            exit(1);
        }
    }
```
The loop was erroneously removed in this commit https://github.com/booksbyus/zguide/commit/aebc4b5aec0b913091a69dc2d1e01211837791f1