### PR TITLE
Improvements to Python Lazy Pirate Implementation

### DIFF
--- a/examples/Python/lpserver.py
+++ b/examples/Python/lpserver.py
@@ -7,13 +7,14 @@
 #
 #   Author: Daniel Lundin <dln(at)eintr(dot)org>
 #
-from __future__ import print_function
-
 from random import randint
+import logging
 import time
 import zmq
 
-context = zmq.Context(1)
+logging.basicConfig(level=logging.INFO)
+
+context = zmq.Context()
 server = context.socket(zmq.REP)
 server.bind("tcp://*:5555")
 
@@ -24,15 +25,12 @@ while True:
 
     # Simulate various problems, after a few cycles
     if cycles > 3 and randint(0, 3) == 0:
-        print("I: Simulating a crash")
+        logging.info("Simulating a crash")
         break
     elif cycles > 3 and randint(0, 3) == 0:
-        print("I: Simulating CPU overload")
+        logging.info("Simulating CPU overload")
         time.sleep(2)
 
-    print("I: Normal request (%s)" % request)
-    time.sleep(1) # Do some heavy work
+    logging.info("Normal request (%s)", request)
+    time.sleep(1)  # Do some heavy work
     server.send(request)
-
-server.close()
-context.term()


### PR DESCRIPTION
I used the socket.poll() function instead of a Poller, because we are only reading from a single socket. This seems like a nice way to show that pyzmq offers this function. 

I switched to using Python's logging module instead of printing strings that start with "I:", "W:", and "E:".

I removed calls to socket.close() and context.term(). The documentation for [close](https://pyzmq.readthedocs.io/en/latest/api/zmq.html#zmq.Socket.close) and [term](https://pyzmq.readthedocs.io/en/latest/api/zmq.html#zmq.Context.term) both say that the socket and context "will automatically be closed when it is garbage collected." The pyzmq examples on [this](https://zeromq.org/languages/python/) page do not call these functions.

I no longer pass `io_threads` to context because `io_threads` defaults to 1. The examples on [this](https://zeromq.org/languages/python/) page also do not do this. 

I removed the check for a null reply, which is required in C but not in Python. 

Lastly, I feel the control flow for lpclient.py is easier to follow now.