### PR TITLE
Lazy Pirate Python Implementation Improvements

### DIFF
--- a/examples/Python/lpserver.py
+++ b/examples/Python/lpserver.py
@@ -8,20 +8,19 @@
 #   Author: Daniel Lundin <dln(at)eintr(dot)org>
 #
 from random import randint
+import itertools
 import logging
 import time
 import zmq
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 
 context = zmq.Context()
 server = context.socket(zmq.REP)
 server.bind("tcp://*:5555")
 
-cycles = 0
-while True:
+for cycles in itertools.count():
     request = server.recv()
-    cycles += 1
 
     # Simulate various problems, after a few cycles
     if cycles > 3 and randint(0, 3) == 0:


### PR DESCRIPTION
I saw that the C implementation does not decrease retries_left when the client sends a reply but it does not match the current sequence number. I have updated the Python implementation to do the same.

I changed the logging statements, so that we do not say "retrying" right before we abandon the connection. 

I changed the formatting of logging statements to look better. 

I added a bitwise and operation to the output of `client.poll()`. This does not change how the if statement functions. But it seems like good practice to encourage, so people don't run into bugs when passing `zmq.POLLIN | zmq.POLLOUT` as the flag parameter to `client.poll()`.