### PR TITLE
Removing obsolete and irrelevant email from CPP examples

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,7 +3,7 @@ Contributors of Examples
 
 Pieter Hintjens <ph@imatix.com> (C, Python)
 Martin Sustrik <sutrik@imatix.com> (C++)
-Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com> (C++)
+Olivier Chamoux <olive.mail@gmx.fr> (C++)
 Naveen Chawla <naveen.chwl@gmail.com> (Java)
 Nicola Peduzzi <thenikso@gmail.com> (Java)
 Isa Hekmatizadeh <esa.hekmat@gmail.com> (Java)

--- a/examples/C++/identity.cpp
+++ b/examples/C++/identity.cpp
@@ -2,7 +2,6 @@
 //  Demonstrate identities as used by the request-reply pattern.  Run this
 //  program by itself.
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
 
 #include <zmq.hpp>
 #include "zhelpers.hpp"

--- a/examples/C++/lbbroker.cpp
+++ b/examples/C++/lbbroker.cpp
@@ -1,7 +1,6 @@
 //  Least-recently used (LRU) queue device
 //  Clients and workers are shown here in-process
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
 
 #include "zhelpers.hpp"
 #include <pthread.h>

--- a/examples/C++/msgqueue.cpp
+++ b/examples/C++/msgqueue.cpp
@@ -2,8 +2,6 @@
 //  Simple message queuing broker in C++
 //  Same as request-reply broker but using QUEUE device
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
-
 
 #include "zhelpers.hpp"
 

--- a/examples/C++/mspoller.cpp
+++ b/examples/C++/mspoller.cpp
@@ -2,7 +2,6 @@
 //  Reading from multiple sockets in C++
 //  This version uses zmq_poll()
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
 
 #include "zhelpers.hpp"
 

--- a/examples/C++/msreader.cpp
+++ b/examples/C++/msreader.cpp
@@ -2,7 +2,6 @@
 //  Reading from multiple sockets in C++
 //  This version uses a simple recv loop
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
 
 
 #include "zhelpers.hpp"

--- a/examples/C++/mtrelay.cpp
+++ b/examples/C++/mtrelay.cpp
@@ -1,8 +1,6 @@
 //
 //  Multithreaded relay in C++
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
-
 
 #include "zhelpers.hpp"
 

--- a/examples/C++/psenvpub.cpp
+++ b/examples/C++/psenvpub.cpp
@@ -2,7 +2,6 @@
 //  Pubsub envelope publisher
 //  Note that the zhelpers.h file also provides s_sendmore
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
 
 #include "zhelpers.hpp"
 

--- a/examples/C++/psenvsub.cpp
+++ b/examples/C++/psenvsub.cpp
@@ -1,7 +1,6 @@
 //
 //  Pubsub envelope subscriber
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
 
 #include "zhelpers.hpp"
 

--- a/examples/C++/rrbroker.cpp
+++ b/examples/C++/rrbroker.cpp
@@ -1,8 +1,6 @@
 //
 //  Simple request-reply broker in C++
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
-
 
 #include "zhelpers.hpp"
 

--- a/examples/C++/rrclient.cpp
+++ b/examples/C++/rrclient.cpp
@@ -2,8 +2,6 @@
 //   Connects REQ socket to tcp://localhost:5559
 //   Sends "Hello" to server, expects "World" back
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
-
 
 #include "zhelpers.hpp"
  

--- a/examples/C++/rrworker.cpp
+++ b/examples/C++/rrworker.cpp
@@ -3,7 +3,6 @@
 //   Connects REP socket to tcp://localhost:5560
 //   Expects "Hello" from client, replies with "World"
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
 
 
 #include "zhelpers.hpp"

--- a/examples/C++/rtdealer.cpp
+++ b/examples/C++/rtdealer.cpp
@@ -1,7 +1,6 @@
 //
 //  Custom routing Router to Dealer
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
 
 #include "zhelpers.hpp"
 #include <pthread.h>

--- a/examples/C++/rtreq.cpp
+++ b/examples/C++/rtreq.cpp
@@ -1,7 +1,6 @@
 //
 //  Custom routing Router to Mama (ROUTER to REQ)
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
 
 #include "zhelpers.hpp"
 #include <pthread.h>

--- a/examples/C++/syncpub.cpp
+++ b/examples/C++/syncpub.cpp
@@ -1,8 +1,6 @@
 //
 //  Synchronized publisher in C++
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
-
 
 #include "zhelpers.hpp"
 

--- a/examples/C++/syncsub.cpp
+++ b/examples/C++/syncsub.cpp
@@ -1,8 +1,6 @@
 //
 //  Synchronized subscriber in C++
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
-
 
 #include "zhelpers.hpp"
 

--- a/examples/C++/tasksink.cpp
+++ b/examples/C++/tasksink.cpp
@@ -3,8 +3,7 @@
 //  Binds PULL socket to tcp://localhost:5558
 //  Collects results from workers via that socket
 //
-//  Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
-//
+
 #include <zmq.hpp>
 #include <time.h>
 #include <sys/time.h>

--- a/examples/C++/tasksink2.cpp
+++ b/examples/C++/tasksink2.cpp
@@ -2,7 +2,6 @@
 //  Task sink in C++ - design 2
 //  Adds pub-sub flow to send kill signal to workers
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
 
 #include "zhelpers.hpp"
 

--- a/examples/C++/taskvent.cpp
+++ b/examples/C++/taskvent.cpp
@@ -3,8 +3,7 @@
 //  Binds PUSH socket to tcp://localhost:5557
 //  Sends batch of tasks to workers via that socket
 //
-//  Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
-//
+
 #include <zmq.hpp>
 #include <stdlib.h>
 #include <stdio.h>

--- a/examples/C++/taskwork.cpp
+++ b/examples/C++/taskwork.cpp
@@ -5,8 +5,7 @@
 //  Connects PUSH socket to tcp://localhost:5558
 //  Sends results to sink via that socket
 //
-//  Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
-//
+
 #include "zhelpers.hpp"
 #include <string>
 

--- a/examples/C++/taskwork2.cpp
+++ b/examples/C++/taskwork2.cpp
@@ -2,7 +2,6 @@
 //  Task worker in C++ - design 2
 //  Adds pub-sub flow to receive and respond to kill signal
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
 
 #include "zhelpers.hpp"
 #include <string>

--- a/examples/C++/wuclient.cpp
+++ b/examples/C++/wuclient.cpp
@@ -3,8 +3,7 @@
 //  Connects SUB socket to tcp://localhost:5556
 //  Collects weather updates and finds avg temp in zipcode
 //
-//  Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
-//
+
 #include <zmq.hpp>
 #include <iostream>
 #include <sstream>

--- a/examples/C++/wuproxy.cpp
+++ b/examples/C++/wuproxy.cpp
@@ -1,8 +1,6 @@
 //
 //  Weather proxy device C++
 //
-// Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
-//
 
 #include "zhelpers.hpp"
 

--- a/examples/C++/wuserver.cpp
+++ b/examples/C++/wuserver.cpp
@@ -3,8 +3,6 @@
 //  Binds PUB socket to tcp://*:5556
 //  Publishes random weather updates
 //
-//  Olivier Chamoux <olivier.chamoux@fr.thalesgroup.com>
-//
 #include <zmq.hpp>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Hello,

It has been more than 10 years since i wrote some of the cpp examples.
Therefore, i would like to remove my email  (pro) from the sources comments, as i don't follow zeromq development anymore (_and prevent misleading people to ask me for help, which i can't provide now_).

Please, notify me if it's not the good way to update this kind of stuff.

Best regards
Olivier Chamoux