### PR TITLE
Fix idententy

### DIFF
--- a/examples/Java/identity.java
+++ b/examples/Java/identity.java
@@ -25,7 +25,7 @@ public class identity
 
             //  Then set the identity ourself
             Socket identified = context.createSocket(SocketType.REQ);
-            identified.setIdentity("Hello".getBytes(ZMQ.CHARSET));
+            identified.setIdentity("PEER2".getBytes(ZMQ.CHARSET));
             identified.connect("inproc://example");
             identified.send("ROUTER socket uses REQ's socket identity", 0);
             ZHelper.dump(sink);


### PR DESCRIPTION
The Java identity example used an identity of "Hello" instead of "PEER2" that the guide discusses. Other language examples (C, C++, Go) use the correct "PEER2" identity.