### PR TITLE
fix s_send report ambiguous error

### DIFF
--- a/examples/C++/rrclient.cpp
+++ b/examples/C++/rrclient.cpp
@@ -14,7 +14,7 @@ int main (int argc, char *argv[])
  
 	for( int request = 0 ; request < 10 ; request++) {
 		
-		s_send (requester, "Hello");
+		s_send (requester, std::string("Hello"));
         std::string string = s_recv (requester);
 		
 		std::cout << "Received reply " << request 


### PR DESCRIPTION
fix compile error under linux g++ "error: call of overloaded ‘s_send(zmq::socket_t&, const char [6])’ is ambiguous"