### PR TITLE
fix compile error under linux g++

### DIFF
--- a/examples/C++/rrworker.cpp
+++ b/examples/C++/rrworker.cpp
@@ -25,7 +25,7 @@ int main (int argc, char *argv[])
         sleep (1);
         
         //  Send reply back to client
-		s_send (responder, "World");
+		s_send (responder, std::string("World"));
 		
 	}
 }


### PR DESCRIPTION
error: call of overloaded ‘s_send(zmq::socket_t&, const char [6])’ is ambiguous