### PR TITLE
Remove redundant static_cast<void*> in examples.

### DIFF
--- a/examples/C++/asyncsrv.cpp
+++ b/examples/C++/asyncsrv.cpp
@@ -35,7 +35,7 @@ public:
         client_socket_.connect("tcp://localhost:5570");
 
         zmq::pollitem_t items[] = {
-            { static_cast<void*>(client_socket_), 0, ZMQ_POLLIN, 0 } };
+            { client_socket_, 0, ZMQ_POLLIN, 0 } };
         int request_nbr = 0;
         try {
             while (true) {

--- a/examples/C++/lbbroker.cpp
+++ b/examples/C++/lbbroker.cpp
@@ -105,10 +105,10 @@ int main(int argc, char *argv[])
 
         //  Initialize poll set
         zmq::pollitem_t items[] = {
-            //  Always poll for worker activity on backend
-                { static_cast<void*>(backend), 0, ZMQ_POLLIN, 0 },
+                //  Always poll for worker activity on backend
+                { backend, 0, ZMQ_POLLIN, 0 },
                 //  Poll front-end only if we have available workers
-                { static_cast<void*>(frontend), 0, ZMQ_POLLIN, 0 }
+                { frontend, 0, ZMQ_POLLIN, 0 }
         };
         if (worker_queue.size())
             zmq::poll(&items[0], 2, -1);

--- a/examples/C++/lpclient.cpp
+++ b/examples/C++/lpclient.cpp
@@ -42,7 +42,7 @@ int main () {
         while (expect_reply) {
             //  Poll socket for a reply, with timeout
             zmq::pollitem_t items[] = {
-                { static_cast<void*>(*client), 0, ZMQ_POLLIN, 0 } };
+                { *client, 0, ZMQ_POLLIN, 0 } };
             zmq::poll (&items[0], 1, REQUEST_TIMEOUT);
 
             //  If we got a reply, process it

--- a/examples/C++/mdbroker.cpp
+++ b/examples/C++/mdbroker.cpp
@@ -392,7 +392,7 @@ public:
       int64_t heartbeat_at = now + HEARTBEAT_INTERVAL;
       while (!s_interrupted) {
           zmq::pollitem_t items [] = {
-              { static_cast<void*>(*m_socket), 0, ZMQ_POLLIN, 0} };
+              { *m_socket, 0, ZMQ_POLLIN, 0} };
           int64_t timeout = heartbeat_at - now;
           if (timeout < 0)
               timeout = 0;

--- a/examples/C++/mdcliapi.hpp
+++ b/examples/C++/mdcliapi.hpp
@@ -107,7 +107,7 @@ public:
            while (!s_interrupted) {
                //  Poll socket for a reply, with timeout
                zmq::pollitem_t items [] = {
-                   { static_cast<void*>(*m_client), 0, ZMQ_POLLIN, 0 } };
+                   { *m_client, 0, ZMQ_POLLIN, 0 } };
                zmq::poll (items, 1, m_timeout);
 
                //  If we got a reply, process it

--- a/examples/C++/mdcliapi2.hpp
+++ b/examples/C++/mdcliapi2.hpp
@@ -103,7 +103,7 @@ public:
    {
        //  Poll socket for a reply, with timeout
        zmq::pollitem_t items[] = {
-           { static_cast<void*>(*m_client), 0, ZMQ_POLLIN, 0 } };
+           { *m_client, 0, ZMQ_POLLIN, 0 } };
        zmq::poll (items, 1, m_timeout);
 
        //  If we got a reply, process it

--- a/examples/C++/mdwrkapi.hpp
+++ b/examples/C++/mdwrkapi.hpp
@@ -132,7 +132,7 @@ public:
 
         while (!s_interrupted) {
             zmq::pollitem_t items[] = {
-                { static_cast<void*>(*m_worker),  0, ZMQ_POLLIN, 0 } };
+                { *m_worker,  0, ZMQ_POLLIN, 0 } };
             zmq::poll (items, 1, m_heartbeat);
 
             if (items[0].revents & ZMQ_POLLIN) {

--- a/examples/C++/mspoller.cpp
+++ b/examples/C++/mspoller.cpp
@@ -21,8 +21,8 @@ int main (int argc, char *argv[])
 
     //  Initialize poll set
     zmq::pollitem_t items [] = {
-        { static_cast<void*>(receiver), 0, ZMQ_POLLIN, 0 },
-        { static_cast<void*>(subscriber), 0, ZMQ_POLLIN, 0 }
+        { receiver, 0, ZMQ_POLLIN, 0 },
+        { subscriber, 0, ZMQ_POLLIN, 0 }
     };
     //  Process messages from both sockets
     while (1) {

--- a/examples/C++/ppqueue.cpp
+++ b/examples/C++/ppqueue.cpp
@@ -110,8 +110,8 @@ int main (void)
 
     while (1) {
         zmq::pollitem_t items [] = {
-            { static_cast<void*>(backend), 0, ZMQ_POLLIN, 0 },
-            { static_cast<void*>(frontend), 0, ZMQ_POLLIN, 0 }
+            { backend, 0, ZMQ_POLLIN, 0 },
+            { frontend, 0, ZMQ_POLLIN, 0 }
         };
         //  Poll frontend only if we have available workers
         if (queue.size()) {

--- a/examples/C++/rrbroker.cpp
+++ b/examples/C++/rrbroker.cpp
@@ -17,8 +17,8 @@ int main (int argc, char *argv[])
 
     //  Initialize poll set
     zmq::pollitem_t items [] = {
-        { static_cast<void*>(frontend), 0, ZMQ_POLLIN, 0 },
-        { static_cast<void*>(backend), 0, ZMQ_POLLIN, 0 }
+        { frontend, 0, ZMQ_POLLIN, 0 },
+        { backend, 0, ZMQ_POLLIN, 0 }
     };
     
     //  Switch messages between sockets

--- a/examples/C++/spqueue.cpp
+++ b/examples/C++/spqueue.cpp
@@ -25,8 +25,8 @@ int main (void)
 
     while (1) {
         zmq::pollitem_t items [] = {
-            { static_cast<void*>(backend), 0, ZMQ_POLLIN, 0 },
-            { static_cast<void*>(frontend), 0, ZMQ_POLLIN, 0 }
+            { backend, 0, ZMQ_POLLIN, 0 },
+            { frontend, 0, ZMQ_POLLIN, 0 }
         };
         //  Poll frontend only if we have available workers
         if (worker_queue.size())

--- a/examples/C++/taskwork2.cpp
+++ b/examples/C++/taskwork2.cpp
@@ -25,8 +25,8 @@ int main (int argc, char *argv[])
 
     //  Process messages from receiver and controller
     zmq::pollitem_t items [] = {
-        { static_cast<void*>(receiver), 0, ZMQ_POLLIN, 0 },
-        { static_cast<void*>(controller), 0, ZMQ_POLLIN, 0 }
+        { receiver, 0, ZMQ_POLLIN, 0 },
+        { controller, 0, ZMQ_POLLIN, 0 }
     };
     //  Process messages from both sockets
     while (1) {

--- a/examples/C++/tripping.cpp
+++ b/examples/C++/tripping.cpp
@@ -73,8 +73,8 @@ broker_task (void *args)
 
     //  Initialize poll set
     zmq::pollitem_t items [] = {
-        { static_cast<void*>(frontend), 0, ZMQ_POLLIN, 0 },
-        { static_cast<void*>(backend), 0, ZMQ_POLLIN, 0 }
+        { frontend, 0, ZMQ_POLLIN, 0 },
+        { backend, 0, ZMQ_POLLIN, 0 }
     };
     while (1) {
         zmq::poll (items, 2, -1);


### PR DESCRIPTION
Not only is it unnecessary because `zmq::socket_t` automatically converts
to `void*` via operator `void*`, it is also misleading as the operator is
called in spite of the appearance that it's "just" a cast.

Now, other comments in `zmq.hpp` indicate that this is not really the
intent (note the comments near the bool conversion), and I believe the
cleanest fix would be to add a member to `zmq::socket_`t that returns the
`void*` needed for polling (`.pollable()`? I really can't find a good name),
or for `zmq::pollitem_t` to handle the conversion instead of having this
magical operator. But since this attempts to document what's there, I
think we should document what is there now while avoiding confusing
bits.  As it is there is a C++ type `zmq::pollitem_t` which can be filled
from `zmq::socket_t` without jumping through hoops, so let's document
that even though one could infer from the man page for `zmq_poll` that
a `static_cast<void*>` is needed.

This PR is related to #858 