### PR TITLE
Replace tab with spaces

### DIFF
--- a/examples/C++/hwserver.cpp
+++ b/examples/C++/hwserver.cpp
@@ -28,7 +28,7 @@ int main () {
         std::cout << "Received Hello" << std::endl;
 
         //  Do some 'work'
-    	sleep(1);
+        sleep(1);
 
         //  Send reply back to client
         zmq::message_t reply (5);


### PR DESCRIPTION
One of the lines included a tab instead of spaces, which made the indentation render badly on my computer (Firefox) since 1 tab was converted to 1 space.

![bild](https://user-images.githubusercontent.com/10755449/132469204-fbb069cf-7807-4cee-9410-0c8cf1c619aa.png)
