### PR TITLE
Correct indentation

### DIFF
--- a/examples/Python/wuclient.py
+++ b/examples/Python/wuclient.py
@@ -27,4 +27,4 @@ for update_nbr in range(5):
     total_temp += int(temperature)
 
     print((f"Average temperature for zipcode " 
-       f"'{zip_filter}' was {total_temp / (update_nbr+1)} F"))
+        f"'{zip_filter}' was {total_temp / (update_nbr+1)} F"))


### PR DESCRIPTION
The example `wuclient.py` at https://zguide.zeromq.org/docs/chapter1/#Getting-the-Message-Out has incorrect indentation at L24 (7 spaces instead of 8 spaces). This PR corrects the indentation.