### PR TITLE
Fix compiler error by adding std::string

### DIFF
--- a/examples/C++/identity.cpp
+++ b/examples/C++/identity.cpp
@@ -16,7 +16,7 @@ int main () {
     zmq::socket_t anonymous(context, ZMQ_REQ);
     anonymous.connect( "inproc://example");
 
-    s_send (anonymous, "ROUTER uses a generated 5 byte identity");
+    s_send (anonymous, std::string("ROUTER uses a generated 5 byte identity"));
     s_dump (sink);
 
     //  Then set the identity ourselves
@@ -24,7 +24,7 @@ int main () {
     identified.setsockopt( ZMQ_IDENTITY, "PEER2", 5);
     identified.connect( "inproc://example");
 
-    s_send (identified, "ROUTER socket uses REQ's socket identity");
+    s_send (identified, std::string("ROUTER socket uses REQ's socket identity"));
     s_dump (sink);
 
     return 0;

--- a/examples/C++/lbbroker.cpp
+++ b/examples/C++/lbbroker.cpp
@@ -22,7 +22,7 @@ client_thread(void *arg) {
 #endif
 
     //  Send request, get reply
-    s_send(client, "HELLO");
+    s_send(client, std::string("HELLO"));
     std::string reply = s_recv(client);
     std::cout << "Client: " << reply << std::endl;
     return (NULL);
@@ -44,7 +44,7 @@ worker_thread(void *arg) {
 #endif
 
     //  Tell backend we're ready for work
-    s_send(worker, "READY");
+    s_send(worker, std::string("READY"));
 
     while (1) {
         //  Read and save all frames until we get an empty frame
@@ -60,8 +60,8 @@ worker_thread(void *arg) {
         std::cout << "Worker: " << request << std::endl;
 
         s_sendmore(worker, address);
-        s_sendmore(worker, "");
-        s_send(worker, "OK");
+        s_sendmore(worker, std::string(""));
+        s_send(worker, std::string("OK"));
     }
     return (NULL);
 }
@@ -140,7 +140,7 @@ int main(int argc, char *argv[])
 
                 std::string reply = s_recv(backend);
                 s_sendmore(frontend, client_addr);
-                s_sendmore(frontend, "");
+                s_sendmore(frontend, std::string(""));
                 s_send(frontend, reply);
 
                 if (--client_nbr == 0)
@@ -164,9 +164,9 @@ int main(int argc, char *argv[])
             worker_queue.pop();
 
             s_sendmore(backend, worker_addr);
-            s_sendmore(backend, "");
+            s_sendmore(backend, std::string(""));
             s_sendmore(backend, client_addr);
-            s_sendmore(backend, "");
+            s_sendmore(backend, std::string(""));
             s_send(backend, request);
         }
     }

--- a/examples/C++/mtrelay.cpp
+++ b/examples/C++/mtrelay.cpp
@@ -15,7 +15,7 @@ void *step1 (void *arg) {
 	zmq::socket_t sender (*context, ZMQ_PAIR);
 	sender.connect("inproc://step2");
 
-	s_send (sender, "");
+	s_send (sender, std::string(""));
 
 	return (NULL);
 }
@@ -39,7 +39,7 @@ void *step2 (void *arg) {
     //  Signal downstream to step 3
     zmq::socket_t sender (*context, ZMQ_PAIR);
     sender.connect("inproc://step3");
-    s_send (sender, "");
+    s_send (sender, std::string(""));
 
     return (NULL);
 }

--- a/examples/C++/pathopub.cpp
+++ b/examples/C++/pathopub.cpp
@@ -28,7 +28,7 @@ int main (int argc, char *argv [])
         ss << std::dec << std::setw(3) << std::setfill('0') << topic_nbr;
 
         s_sendmore (publisher, ss.str());
-        s_send (publisher, "Save Roger");
+        s_send (publisher, std::string("Save Roger"));
     }
 
     //  Send one random update per second
@@ -39,7 +39,7 @@ int main (int argc, char *argv [])
         ss << std::dec << std::setw(3) << std::setfill('0') << within(1000);
 
         s_sendmore (publisher, ss.str());
-        s_send (publisher, "Off with his head!");
+        s_send (publisher, std::string("Off with his head!"));
     }
     return 0;
 }

--- a/examples/C++/ppworker.cpp
+++ b/examples/C++/ppworker.cpp
@@ -32,7 +32,7 @@ s_worker_socket (zmq::context_t &context) {
 
     //  Tell queue we're ready for work
     std::cout << "I: (" << identity << ") worker ready" << std::endl;
-    s_send (*worker, "READY");
+    s_send (*worker, std::string("READY"));
 
     return worker;
 }
@@ -113,7 +113,7 @@ int main (void)
         if (s_clock () > heartbeat_at) {
             heartbeat_at = s_clock () + HEARTBEAT_INTERVAL;
             std::cout << "I: (" << identity << ") worker heartbeat" << std::endl;
-            s_send (*worker, "HEARTBEAT");
+            s_send (*worker, std::string("HEARTBEAT"));
         }
     }
     delete worker;

--- a/examples/C++/psenvpub.cpp
+++ b/examples/C++/psenvpub.cpp
@@ -13,10 +13,10 @@ int main () {
 
     while (1) {
         //  Write two messages, each with an envelope and content
-        s_sendmore (publisher, "A");
-        s_send (publisher, "We don't want to see this");
-        s_sendmore (publisher, "B");
-        s_send (publisher, "We would like to see this");
+        s_sendmore (publisher, std::string("A"));
+        s_send (publisher, std::string("We don't want to see this"));
+        s_sendmore (publisher, std::string("B"));
+        s_send (publisher, std::string("We would like to see this"));
         sleep (1);
     }
     return 0;

--- a/examples/C++/rtdealer.cpp
+++ b/examples/C++/rtdealer.cpp
@@ -22,8 +22,8 @@ worker_task(void *args)
     int total = 0;
     while (1) {
         //  Tell the broker we're ready for work
-        s_sendmore(worker, "");
-        s_send(worker, "Hi Boss");
+        s_sendmore(worker, std::string(""));
+        s_send(worker, std::string("Hi Boss"));
 
         //  Get workload from broker, until finished
         s_recv(worker);     //  Envelope delimiter
@@ -72,13 +72,13 @@ int main() {
         }
 
         s_sendmore(broker, identity);
-        s_sendmore(broker, "");
+        s_sendmore(broker, std::string(""));
 
         //  Encourage workers until it's time to fire them
         if (s_clock() < end_time)
-            s_send(broker, "Work harder");
+            s_send(broker, std::string("Work harder"));
         else {
-            s_send(broker, "Fired!");
+            s_send(broker, std::string("Fired!"));
             if (++workers_fired == NBR_WORKERS)
                 break;
         }

--- a/examples/C++/rtreq.cpp
+++ b/examples/C++/rtreq.cpp
@@ -22,7 +22,7 @@ worker_thread(void *arg) {
     int total = 0;
     while (1) {
         //  Tell the broker we're ready for work
-        s_send(worker, "Hi Boss");
+        s_send(worker, std::string("Hi Boss"));
 
         //  Get workload from broker, until finished
         std::string workload = s_recv(worker);
@@ -64,12 +64,12 @@ int main() {
         s_recv(broker);     //  Response from worker       
         
         s_sendmore(broker, identity);
-        s_sendmore(broker, "");
+        s_sendmore(broker, std::string(""));
         //  Encourage workers until it's time to fire them
         if (s_clock() < end_time)
-            s_send(broker, "Work harder");
+            s_send(broker, std::string("Work harder"));
         else {
-            s_send(broker, "Fired!");
+            s_send(broker, std::string("Fired!"));
             if (++workers_fired == NBR_WORKERS)
                 break;
         }

--- a/examples/C++/spworker.cpp
+++ b/examples/C++/spworker.cpp
@@ -19,7 +19,7 @@ int main (void)
 
     //  Tell queue we're ready for work
     std::cout << "I: (" << identity << ") worker ready" << std::endl;
-    s_send (worker, "READY");
+    s_send (worker, std::string("READY"));
 
     int cycles = 0;
     while (1) {

--- a/examples/C++/syncpub.cpp
+++ b/examples/C++/syncpub.cpp
@@ -30,7 +30,7 @@ int main () {
 		s_recv (syncservice);
        
 		//  - send synchronization reply
-		s_send (syncservice, "");
+		s_send (syncservice, std::string(""));
 
 
         subscribers++;
@@ -39,10 +39,10 @@ int main () {
     //  Now broadcast exactly 1M updates followed by END
     int update_nbr;
     for (update_nbr = 0; update_nbr < 1000000; update_nbr++) {	
-		s_send (publisher, "Rhubarb");
+		s_send (publisher, std::string("Rhubarb"));
 	}
 	
-    s_send (publisher, "END");
+    s_send (publisher, std::string("END"));
 
     sleep (1);              //  Give 0MQ time to flush output
     return 0;

--- a/examples/C++/syncsub.cpp
+++ b/examples/C++/syncsub.cpp
@@ -18,7 +18,7 @@ int main (int argc, char *argv[])
     syncclient.connect("tcp://localhost:5562");
 
     //  - send a synchronization request
-    s_send (syncclient, "");
+    s_send (syncclient, std::string(""));
 
     //  - wait for synchronization reply
     s_recv (syncclient);


### PR DESCRIPTION
Issue: the example code can't be built by `g++ -lzmq syncsub.cpp -o syncsub`. It throws `error: call of overloaded ‘s_send(zmq::socket_t&, const char [1])’ is ambiguous`.
Solution: Add the std::string