### PR TITLE
Fix build script error due to dependency on mit-krb5.cpp

### DIFF
--- a/examples/C++/build
+++ b/examples/C++/build
@@ -5,7 +5,7 @@
 #
 ZMQOPTS='-lzmq -std=c++11'
 if pkg-config libzmq --exists; then
-    ZMQOPTS="$(pkg-config libzmq --cflags --libs) -std=c++11"
+    ZMQOPTS="$(pkg-config libzmq --libs) -std=c++11"
 fi
 if [ /$1/ = /all/ ]; then
     echo "Building C++ examples..."


### PR DESCRIPTION
Reason: Compiler error `cc1plus: fatal error: /usr/include/mit-krb5.cpp: No such file or directory`
Fix: Remove the dependency to the mit-krb5.cpp which comes from the output of the pkg-config with `--cflags`