### PR TITLE
Delete duplicate file

### DIFF
--- a/examples/Java/readme
+++ b/examples/Java/readme
@@ -1,2 +1,0 @@
-Examples in Java
-See LICENSE in examples directory


### PR DESCRIPTION
Prevents the following warning when cloning on case-insensitive filesystems (e.g. Windows/OSX)

```
warning: the following paths have collided (e.g. case-sensitive paths on a case-insensitive filesystem) and only one from the same colliding group is in the working tree:

  'examples/Java/README'
  'examples/Java/readme'
```