### PR TITLE
Fixed incorrect example code

### DIFF
--- a/examples/Python/lvcache.py
+++ b/examples/Python/lvcache.py
@@ -45,7 +45,7 @@ def main():
         if backend in events:
             event = backend.recv()
             # Event is one byte 0=unsub or 1=sub, followed by topic
-            if event[0] == b'\x01':
+            if event[0] == 1:
                 topic = event[1:]
                 if topic in cache:
                     print ("Sending cached topic %s" % topic)


### PR DESCRIPTION
As of V4.3.4 and pyzmq 25.0.1, this example did not work thanks to the comparison of the first byte of a new subscriber being incorrect.

the XPUB socket returns a byte string where the first byte has the same value as an integer of 1, but the example code shows that you should expect a value of b"\x01" which takes up four bytes and doesn't work in practice even though at first glance it appears correct.

The correct code is to just compare event[0] == 1 which adheres to the specification and works in real tests of this example.