### PR TITLE
Add missing single quotes to null-terminator

### DIFF
--- a/site/content/docs/chapter1.md
+++ b/site/content/docs/chapter1.md
@@ -139,7 +139,7 @@ s_recv (void *socket) {
         return NULL;
     if (size > 255)
         size = 255;
-    buffer [size] = \0;
+    buffer [size] = '\0';
     /* use strndup(buffer, sizeof(buffer)-1) in *nix */
     return strdup (buffer);
 }


### PR DESCRIPTION
This example is missing single quotes around `\0`

```C
//  Receive ZeroMQ string from socket and convert into C string
//  Chops string at 255 chars, if it's longer
static char *
s_recv (void *socket) {
    char buffer [256];
    int size = zmq_recv (socket, buffer, 255, 0);
    if (size == -1)
        return NULL;
    if (size > 255)
        size = 255;
    buffer [size] = \0;
    /* use strndup(buffer, sizeof(buffer)-1) in *nix */
    return strdup (buffer);
}
```