### PR TITLE
add lazy pirate rust examples

### DIFF
--- a/examples/Rust/Cargo.toml
+++ b/examples/Rust/Cargo.toml
@@ -12,6 +12,14 @@ path = "./hwserver.rs"
 name = "hwserver"
 
 [[bin]]
+path = "./lpclient.rs"
+name = "lpclient"
+
+[[bin]]
+path = "./lpserver.rs"
+name = "lpserver"
+
+[[bin]]
 path = "./msgqueue.rs"
 name = "msgqueue"
 

--- a/examples/Rust/lpclient.rs
+++ b/examples/Rust/lpclient.rs
@@ -1,0 +1,64 @@
+#![crate_name = "lpclient"]
+
+use std::time::Duration;
+use std::convert::TryInto;
+extern crate zmq;
+
+const REQUEST_TIMEOUT: i64 = 2500;
+const REQUEST_RETRIES: usize = 3;
+const SERVER_ENDPOINT: &'static str = "tcp://localhost:5555";
+
+fn connect(context: &zmq::Context) -> zmq::Socket {
+    let socket = context.socket(zmq::REQ).unwrap();
+    socket.set_linger(0).unwrap();
+    socket.connect(SERVER_ENDPOINT).unwrap();
+    socket
+}
+
+fn reconnect(context: &zmq::Context, socket: zmq::Socket) -> zmq::Socket {
+    drop(socket);
+    connect(context)
+}
+
+fn main() {
+    let mut retries_left = REQUEST_RETRIES;
+
+    let context = zmq::Context::new();
+    let mut socket = connect(&context);
+
+    let mut i = 0i64;
+    loop {
+        let value = i.to_le_bytes();
+        i += 1;
+        while retries_left > 0 {
+            retries_left -= 1;
+
+            let request = zmq::Message::from(&value.as_slice());
+            println!("Sending request {request:?}");
+            socket.send(request, 0).unwrap();
+
+            if socket.poll(zmq::POLLIN, REQUEST_TIMEOUT).unwrap() != 0 {
+                let reply = socket.recv_msg(0).unwrap();
+                let reply_content =
+                    TryInto::<[u8; 8]>::try_into(&*reply).and_then(|x| Ok(i64::from_le_bytes(x)));
+                if let Ok(i) = reply_content {
+                    println!("Server replied OK {i}");
+                    retries_left = REQUEST_RETRIES;
+                    break;
+                } else {
+                    println!("Malformed message: {reply:?}");
+                    continue;
+                }
+            }
+            println!("No response from Server");
+            println!("Reconnecting server...");
+            socket = reconnect(&context, socket);
+            println!("Resending Request");
+        }
+
+        if retries_left == 0 {
+            println!("Server is offline. Goodbye...");
+            return;
+        }
+    }
+}

--- a/examples/Rust/lpserver.rs
+++ b/examples/Rust/lpserver.rs
@@ -1,0 +1,32 @@
+#![crate_name = "lpserver"]
+
+use rand::{thread_rng, Rng};
+use std::time::Duration;
+extern crate rand;
+extern crate zmq;
+
+fn main() {
+    let context = zmq::Context::new();
+    let server = context.socket(zmq::REP).unwrap();
+    server.bind("tcp://*:5555").unwrap();
+
+    let mut i = 0;
+    loop {
+        i += 1;
+        let request = server.recv_msg(0).unwrap();
+        println!("Got Request: {request:?}");
+        server.send(request, 0).unwrap();
+        std::thread::sleep(Duration::from_secs(1));
+
+        if (i > 3) && (thread_rng().gen_range(0, 3) == 0) {
+            // simulate a crash
+            println!("Oh no! Server crashed.");
+            break;
+        }
+        if (i > 3) && (thread_rng().gen_range(0, 3) == 0) {
+            // simulate overload
+            println!("Server is busy.");
+            std::thread::sleep(Duration::from_secs(2));
+        }
+    }
+}


### PR DESCRIPTION
Adds server and client translations to Rust for the lazy pirate pattern.