### PR TITLE
Enhacements/cpp examples

### DIFF
--- a/examples/C++/interrupt.cpp
+++ b/examples/C++/interrupt.cpp
@@ -1,47 +1,38 @@
-//  Handling Interrupt Signals in C++
-//
-//  Zaytsev Roman Borisovich <roman.zaytsev.borisovich@gmail.com>
-
+#include <csignal>
 #include <iostream>
-#include <signal.h>
 #include <zmq.hpp>
 
-static volatile int s_interrupted = 0;
-static void s_signal_handler (int signal_value)
-{
-    s_interrupted = 1;
+int interrupted{0};
+
+void signal_handler(int signal_value) { interrupted = 1; }
+
+void catch_signals() {
+  std::signal(SIGINT, signal_handler);
+  std::signal(SIGTERM, signal_handler);
+  std::signal(SIGSEGV, signal_handler);
+  std::signal(SIGABRT, signal_handler);
 }
 
-static void s_catch_signals (void)
-{
-    struct sigaction action;
-    action.sa_handler = s_signal_handler;
-    action.sa_flags = 0;
-    sigemptyset (&action.sa_mask);
-    sigaction (SIGINT, &action, NULL);
-    sigaction (SIGTERM, &action, NULL);
-}
+int main() {
+  zmq::context_t ctx(1);
 
-int main (void)
-{
-    zmq::context_t context (1);
-    zmq::socket_t socket (context, ZMQ_REP);
-    socket.bind ("tcp://*:5555");
+  zmq::socket_t socket(ctx, ZMQ_REP);
+  socket.bind("tcp://localhost:5555");
 
-    s_catch_signals ();
-    while ( true ) {
-        //  Blocking read will throw on a signal
-        zmq::message_t msg;
-        try {
-            socket.recv (&msg);
-        }
-        catch(zmq::error_t& e) {
-            std::cout << "W: interrupt received, proceeding…" << std::endl;
-        }
-        if (s_interrupted) {
-            std::cout << "W: interrupt received, killing server…" << std::endl;
-            break;
-        }
+  catch_signals();
+  while (true) {
+    zmq::message_t msg;
+
+    try {
+      socket.recv(&msg);
+    } catch (zmq::error_t &e) {
+      std::cout << "interrupt received, proceeding..." << std::endl;
     }
-    return 0;
+
+    if (interrupted) {
+      std::cout << "interrupt received, killing program..." << std::endl;
+      break;
+    }
+  }
+  return 0;
 }

--- a/examples/C++/interrupt.cpp
+++ b/examples/C++/interrupt.cpp
@@ -1,3 +1,6 @@
+/* 
+ author: saad hussain (saadnasir31@gmail.com)
+*/
 #include <csignal>
 #include <iostream>
 #include <zmq.hpp>


### PR DESCRIPTION
Handling interrupts in C++ examples using csignal's std::signal instead of linux's signal handling mechanism. 