### PR TITLE
Pascal patch

### DIFF
--- a/examples/Free Pascal/hwclient.pas
+++ b/examples/Free Pascal/hwclient.pas
@@ -1,0 +1,33 @@
+{
+  Hello World client
+  Connects REQ socket to tcp://localhost:5555
+  Sends "Hello" to server, expects "World" back
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program hwclient;
+
+{$MODE objfpc}{$H+}
+
+uses zmq;
+
+var
+  context, requester : Pointer;
+  i : integer;
+  buffer : array [0..4] of Char; 
+  S : string = 'Hello'; // ansistring
+
+begin
+  WriteLn('Connecting to hello world server…');
+  context := zmq_ctx_new;
+  requester := zmq_socket(context, ZMQ_REQ);
+  zmq_connect(requester, 'tcp://localhost:5555');
+  for i := 0 to 9 do
+    begin
+      WriteLn('Sending '+S+'…');
+      zmq_send(requester, @S[1], Length(S), 0);
+      zmq_recv(requester, @buffer, Length(buffer), 0);
+      WriteLn('Received ', buffer);
+    end;
+  zmq_close(requester);
+  zmq_ctx_destroy(context);
+end.

--- a/examples/Free Pascal/hwserver.pas
+++ b/examples/Free Pascal/hwserver.pas
@@ -1,0 +1,33 @@
+{
+  Hello World server
+  Binds REP socket to tcp://*:5555
+  Expects "Hello" from client, replies with "World"
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program hwserver;
+
+{$MODE objfpc}{$H+}
+
+uses SysUtils, zmq;
+
+var
+  context, responder: Pointer;
+  rc : integer = 0;
+  buffer : array [0..4] of Char;
+  S : string[5] = 'World'; // ansistring
+begin
+  //  Socket to talk to clients
+  context := zmq_ctx_new;
+  responder := zmq_socket(context, ZMQ_REP);
+  rc := zmq_bind(responder, 'tcp://*:5555');
+  Assert(rc = 0);
+  WriteLn('hello world server initialized…');
+  while True do
+    begin
+      zmq_recv(responder, @buffer, Length(buffer), 0);
+      Writeln('Received ', buffer);
+      Sleep(1000); //  Do some 'work'
+      WriteLn('Sending '+S+'…');
+      zmq_send(responder, @S[1], Length(S), 0);
+    end;
+end.

--- a/examples/Free Pascal/identity.pas
+++ b/examples/Free Pascal/identity.pas
@@ -1,0 +1,36 @@
+{
+  //  Demonstrate request-reply identities
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program identity;
+
+{$mode objfpc}{$H+}
+
+uses SysUtils, zmq, zmq.helpers;
+
+var
+  context, sink, anonymous, identified: Pointer;
+  optval : string = 'PEER2';
+begin
+  context := zmq_ctx_new;
+  sink := zmq_socket(context, ZMQ_ROUTER);
+  zmq_bind(sink, 'inproc://example');
+
+  //  First allow 0MQ to set the identity
+  anonymous := zmq_socket(context, ZMQ_REQ);
+  zmq_connect(anonymous, 'inproc://example');
+  s_send(anonymous, 'ROUTER uses a generated 5 byte identity');
+  s_dump(sink);
+
+  //  Then set the identity ourselves
+  identified := zmq_socket(context, ZMQ_REQ);
+  zmq_setsockopt(identified, ZMQ_IDENTITY, @optval[1], 5);
+  zmq_connect(identified, 'inproc://example');
+  s_send(identified, 'ROUTER socket uses REQ''s socket identity');
+  s_dump(sink);
+
+  zmq_close(sink);
+  zmq_close(anonymous);
+  zmq_close(identified);
+  zmq_ctx_destroy (context);
+end.

--- a/examples/Free Pascal/interrupt.pas
+++ b/examples/Free Pascal/interrupt.pas
@@ -1,0 +1,149 @@
+{
+  Shows how to ugly handle Ctrl-C in unix systems
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program interrupt;
+
+{$mode objfpc}{$H+}
+
+uses
+  SysUtils, initc, BaseUnix, UNIX,
+  zmq, zmq.helpers;
+
+function read_(__fd:longint; __buf:pointer; __nbytes:size_t):ssize_t;cdecl;external clib name 'read';
+function write_(__fd:longint; __buf:pointer; __n:size_t):ssize_t;cdecl;external clib name 'write';
+
+//  Signal handling
+//
+//  Create a self-pipe and call s_catch_signals(pipe's writefd) in your application
+//  at startup, and then exit your main loop if your pipe contains any data.
+//  Works especially well with zmq_poll.
+const
+  STDOUT_FILENO = 1;
+
+var
+  S_NOTIFY_MSG : string = #32;
+  S_ERROR_MSG : string = 'Error while writing to self-pipe'+LineEnding;
+
+  s_fd : integer;
+
+  rc, flags , i: integer;
+  pipefds : TFilDes;
+  items : array [0..1] of zmq_pollitem_t;
+  context, lsocket: Pointer;
+
+  buffer1 : string[1];
+  buffer2 : string[255];
+
+procedure s_signal_handler(signal: longint; info: psiginfo; context: psigcontext); cdecl;
+var
+  rc : integer;
+begin
+  rc := write_(s_fd, @S_NOTIFY_MSG[1], Length(S_NOTIFY_MSG));
+  if rc <> Length(S_NOTIFY_MSG) then
+  begin
+    write_(STDOUT_FILENO, @S_ERROR_MSG[1], Length(S_ERROR_MSG)-1);
+    Halt(1);
+  end;
+end;
+
+procedure s_catch_signals(fd : integer);
+var
+  action : sigactionrec;
+begin
+  s_fd := fd;
+  action.sa_handler := @s_signal_handler;
+  //  Doesn't matter if SA_RESTART set because self-pipe will wake up zmq_poll
+  //  But setting to 0 will allow zmq_read to be interrupted.
+  action.sa_flags := 0;
+  FpsigEmptySet(action.sa_mask);
+  FPSigaction(ESysEINTR, @action, nil);
+  FPSigaction(SIGTERM, @action, nil);
+end;
+begin
+  context := zmq_ctx_new;
+  lsocket := zmq_socket(context, ZMQ_REP);
+  zmq_bind(lsocket, 'tcp://*:5555');
+  try
+    rc := fppipe(pipefds);
+    if rc <> 0 then
+    begin
+      WriteLn(StdErr, 'Creating self-pipe');
+      Halt(1);
+    end;
+    for i := 0 to 1 do
+    begin
+        flags := fpfcntl(pipefds[0], F_GETFL, 0);
+        if flags < 0 then
+        begin
+          WriteLn(StdErr, 'fcntl(F_GETFL)');
+          Halt(1);
+        end;
+        rc := fpfcntl(pipefds[0], F_SETFL, flags or O_NONBLOCK);
+        if rc <> 0 then
+        begin
+          WriteLn(StdErr, 'fcntl(F_SETFL)');
+          Halt(1);
+        end;
+    end;
+
+    s_catch_signals(pipefds[1]);
+
+    with items[0] do
+    begin
+      socket := nil;
+      fd := pipefds[0];
+      events := ZMQ_POLLIN;
+      revents := 0;
+    end;
+
+    with items[1] do
+    begin
+      socket := lsocket;
+      fd := 0;
+      events := ZMQ_POLLIN;
+      revents := 0;
+    end;
+
+    repeat
+      rc := zmq_poll(items[0], 2, -1);
+      if rc = 0 then continue
+      else if rc < 0 then
+      begin
+        if fpgeterrno = ESysEINTR then continue;
+        WriteLn(StdErr, 'zmq_poll');
+        Halt(1);
+      end;
+
+      // Signal pipe FD
+      if (items[0].revents and ZMQ_POLLIN) > 0 then
+      begin
+        read_(pipefds[0], @buffer1[1], 1);  // clear notifying byte
+        WriteLn('W: interrupt received, killing server…');
+        break;
+      end;
+
+      // Read socket
+      if (items[1].revents and ZMQ_POLLIN) > 0 then
+      begin
+        // Use non-blocking so we can continue to check self-pipe via zmq_poll
+        rc := zmq_recv(lsocket, @buffer2[1], 255, ZMQ_NOBLOCK);
+        if rc < 0 then
+          if fpgeterrno = ESysEAGAIN then continue;
+          if fpgeterrno = ESysEINTR then continue;
+          WriteLn(StdErr, 'recv');
+          Halt(1);
+        end;
+        WriteLn('W: recv');
+
+        // Now send message back.
+        // …
+    until False;
+
+
+  finally
+    WriteLn('W: cleaning up');
+    zmq_close(lsocket);
+    zmq_ctx_destroy(context);
+  end;
+end.

--- a/examples/Free Pascal/lbbroker.pas
+++ b/examples/Free Pascal/lbbroker.pas
@@ -1,0 +1,249 @@
+{
+  Load-balancing broker
+  Clients and workers are shown here in-process
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program lbbroker;
+
+{$mode objfpc}{$H+}{$COPERATORS ON}
+
+uses
+  {$IFDEF UNIX}cthreads, cmem{$ENDIF}, SysUtils,
+  zmq, zmq.helpers, zmq.types;
+
+//  Dequeue operation for queue implemented as array of string
+procedure DEQUEUE(var q: array of string);
+  function QueueSize(S : array of string): LongWord;
+  var
+    i : integer;
+  begin
+    Result := 0;
+    for i := Low(s) to High(s) do
+      Result += SizeOf(S[i]);
+  end;
+begin
+  Move(q[1], q[0], QueueSize(q) - SizeOf(q[0]));
+end;
+
+//  Basic request-reply client using REQ socket
+//  Because s_send and s_recv can't handle 0MQ binary identities, we
+//  set a printable text identity to allow routing.
+
+function client_task(args: pointer):PtrInt;
+var
+  context, client: Pointer;
+  reply : string;
+begin
+  context := zmq_ctx_new;
+  client := zmq_socket(context, ZMQ_REQ);
+
+{$IFDEF WIN32}
+  s_set_id(client, PtrInt(args));
+  zmq_connect(client, 'tcp://localhost:5672'); // frontend
+{$ELSE}
+  s_set_id(client); // Set a printable identity
+  zmq_connect(client, 'ipc://frontend.ipc');
+{$ENDIF}
+
+  //  Send request, get reply
+  s_send(client, 'HELLO');
+  reply := s_recv(client);
+  WriteLn('Client: '+reply);
+  reply := '';
+  zmq_close(client);
+  zmq_ctx_destroy(context);
+  Result := PtrInt(0);
+end;
+//  While this example runs in a single process, that is just to make
+//  it easier to start and stop the example. Each thread has its own
+//  context and conceptually acts as a separate process.
+//  This is the worker task, using a REQ socket to do load-balancing.
+//  Because s_send and s_recv can't handle 0MQ binary identities, we
+//  set a printable text identity to allow routing.
+
+function worker_task(args: pointer): PtrInt;
+var
+  context, worker: Pointer;
+  identity, request, empty: string;
+begin
+  context := zmq_ctx_new;
+  worker := zmq_socket(context, ZMQ_REQ);
+
+{$IFDEF WIN32}
+  s_set_id(worker, PtrInt(args));
+  zmq_connect(worker, 'tcp://localhost:5673'); // backend
+{$ELSE}
+  s_set_id(worker);
+  zmq_connect(worker, 'ipc://backend.ipc');
+{$ENDIF}
+
+  //  Tell broker we're ready for work
+  s_send(worker, 'READY');
+
+  repeat
+    //  Read and save all frames until we get an empty frame
+    //  In this example there is only 1, but there could be more
+    identity := s_recv(worker);
+    empty := s_recv(worker);
+    Assert(empty = '');
+    empty := '';
+
+    //  Get request, send reply
+    request := s_recv(worker);
+    WriteLn('Worker: '+request);
+    request := '';
+
+    s_sendmore(worker, identity);
+    s_sendmore(worker, '');
+    s_send(worker, 'OK');
+    identity := '';
+  until False;
+  zmq_close(worker);
+  zmq_ctx_destroy(context);
+  Result := PtrInt(0);
+end;
+
+//  This is the main task. It starts the clients and workers, and then
+//  routes requests between the two layers. Workers signal READY when
+//  they start; after that we treat them as ready when they reply with
+//  a response back to a client. The load-balancing data structure is
+//  just a queue of next available workers.
+
+const
+  NBR_CLIENTS = 10;
+  NBR_WORKERS =  3;
+
+var
+  context, frontend, backend: Pointer;
+  client_nbr, worker_nbr, available_workers, rc: Integer;
+
+  worker_queue : array of string;
+  items : array [0..1] of zmq_pollitem_t;
+
+  worker_id, empty, client_id, reply, request : string;
+
+begin
+  //  Prepare our context and sockets
+  context := zmq_ctx_new;
+  frontend := zmq_socket(context, ZMQ_ROUTER);
+  backend := zmq_socket(context, ZMQ_ROUTER);
+
+{$IFDEF WIN32}
+  zmq_bind(frontend, 'tcp://*:5672'); // frontend
+  zmq_bind(backend, 'tcp://*:5673'); // backend
+{$ELSE}
+  zmq_bind(frontend, 'ipc://frontend.ipc');
+  zmq_bind(backend, 'ipc://backend.ipc');
+{$ENDIF}
+
+  for client_nbr := 0 to  NBR_CLIENTS -1 do
+    BeginThread(@client_task, @client_nbr);
+
+  for worker_nbr := 0 to NBR_WORKERS -1 do
+    BeginThread(@worker_task, @worker_nbr);
+
+  //  Here is the main loop for the least-recently-used queue. It has two
+  //  sockets; a frontend for clients and a backend for workers. It polls
+  //  the backend in all cases, and polls the frontend only when there are
+  //  one or more workers ready. This is a neat way to use 0MQ's own queues
+  //  to hold messages we're not ready to process yet. When we get a client
+  //  reply, we pop the next available worker and send the request to it,
+  //  including the originating client identity. When a worker replies, we
+  //  requeue that worker and forward the reply to the original client
+  //  using the reply envelope.
+
+  //  Queue of available workers
+  available_workers := 0;
+  SetLength(worker_queue, 10);
+  repeat
+    with items[0] do
+    begin
+      socket := backend;
+      fd := 0;
+      events := ZMQ_POLLIN;
+      revents := 0;
+    end;
+    with items[1] do
+    begin
+      socket := frontend;
+      fd := 0;
+      events := ZMQ_POLLIN;
+      revents := 0;
+    end;
+
+    //  Poll frontend only if we have available workers
+    if available_workers = 2 then
+      rc := zmq_poll(items[0], 2, -1)
+    else
+      rc := zmq_poll(items[0], 1, -1);
+
+    if rc = -1 then break; //  Interrupted
+
+    //  Handle worker activity on backend
+    if (items[0].revents and ZMQ_POLLIN) > 0 then
+    begin
+      //  Queue worker identity for load-balancing
+      worker_id := s_recv(backend);
+      Assert(available_workers < NBR_WORKERS);
+      worker_queue[available_workers] := worker_id;
+      available_workers += 1;
+
+      //  Second frame is empty
+      empty := s_recv(backend);
+      Assert(empty = '');
+      empty := '';
+
+      //  Third frame is READY or else a client reply identity
+      client_id := s_recv(backend);
+
+      //  If client reply, send rest back to frontend
+      if client_id <> 'READY' then
+        begin
+          empty := s_recv(backend);
+          Assert(empty = '');
+          empty := '';
+
+          reply := s_recv(backend);
+          s_sendmore(frontend, client_id);
+          s_sendmore(frontend, '');
+          s_send(frontend, reply);
+          reply := '';
+          client_nbr -= 1;
+          if client_nbr = 0 then break; //  Exit after N messages
+        end;
+
+      client_id := '';
+    end;
+    //  Here is how we handle a client request:
+
+    if (items[1].revents and ZMQ_POLLIN) > 0 then
+    begin
+      //  Now get next client request, route to last-used worker
+      //  Client request is [identity][empty][request]
+      client_id := s_recv(frontend);
+      empty := s_recv(frontend);
+      Assert(empty = '');
+      empty := '';
+
+      request := s_recv(frontend);
+
+      s_sendmore(backend, worker_queue[0]);
+      s_sendmore(backend, '');
+      s_sendmore(backend, client_id);
+      s_sendmore(backend, '');
+      s_send(backend, request);
+
+      client_id := '';
+      request := '';
+
+      //  Dequeue and drop the next worker identity
+      worker_queue[0] := '';
+      DEQUEUE(worker_queue);
+      available_workers -= 1;
+    end;
+  until False;
+  zmq_close(frontend);
+  zmq_close(backend);
+  zmq_ctx_destroy(context);
+end.
+

--- a/examples/Free Pascal/msgqueue.pas
+++ b/examples/Free Pascal/msgqueue.pas
@@ -1,0 +1,36 @@
+{
+  Simple message queuing broker
+  Same as request-reply broker but using shared queue proxy
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program msgqueue;
+
+{$mode objfpc}{$H+}
+
+uses zmq;
+
+var
+  context, frontend, backend: Pointer;
+  rc: Integer;
+begin
+  context := zmq_ctx_new;
+
+  // Socket facing clients
+  frontend := zmq_socket(context, ZMQ_ROUTER);
+  rc := zmq_bind(frontend, 'tcp://*:5559');
+  Assert(rc = 0);
+
+  // Socket facing services
+  backend := zmq_socket(context, ZMQ_DEALER);
+  rc := zmq_bind(backend, 'tcp://*:5560');
+  Assert(rc = 0);
+
+  // Start the proxy
+  zmq_proxy(frontend, backend, nil);
+
+  // We never get here…
+  zmq_close(frontend);
+  zmq_close(backend);
+  zmq_ctx_destroy(context);
+end.
+

--- a/examples/Free Pascal/mspoller.pas
+++ b/examples/Free Pascal/mspoller.pas
@@ -1,0 +1,61 @@
+{
+  Reading from multiple sockets
+  This version uses zmq_poll()
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program mspoller;
+
+{$MODE objfpc}{$H+}
+
+uses zmq, zmq.helpers;
+
+var
+  context, receiver, subscriber: Pointer;
+  filter : string = '10001';
+  items : array [0..1] of zmq_pollitem_t;
+  msg : array [0..255] of Char;
+  size: Integer;
+begin
+  //  Connect to task ventilator
+  context := zmq_ctx_new;
+  receiver := zmq_socket(context, ZMQ_PULL);
+  zmq_connect(receiver, 'tcp://localhost:5557');
+
+  //  Connect to weather server
+  subscriber := zmq_socket(context, ZMQ_SUB);
+  zmq_connect(subscriber, 'tcp://localhost:5556');
+  zmq_setsockopt(subscriber, ZMQ_SUBSCRIBE, @filter[1], Length(filter));
+
+  //  Process messages from both sockets
+  repeat
+    FillChar(msg, SizeOf(msg), 0);
+    with items[0] do
+    begin
+      socket := receiver;
+      fd := 0;
+      events := ZMQ_POLLIN;
+      revents := 0;
+    end;
+    with items[1] do
+    begin
+      socket := subscriber;
+      fd := 0;
+      events := ZMQ_POLLIN;
+      revents := 0;
+    end;
+
+    zmq_poll(items[0], Length(items), -1);
+    if (items[0].revents and ZMQ_POLLIN) > 0 then
+    begin
+      size := zmq_recv(receiver,   @msg, 255, 0);
+      if (size <> -1) then ; //  Process task
+    end;
+    if (items[1].revents and ZMQ_POLLIN) > 0 then
+    begin
+      size := zmq_recv(subscriber, @msg, 255, 0);
+      if (size <> -1) then ; //  Process weather update
+    end;
+  until False;
+  zmq_close(subscriber);
+  zmq_ctx_destroy(context);
+end.

--- a/examples/Free Pascal/msread.pas
+++ b/examples/Free Pascal/msread.pas
@@ -1,0 +1,49 @@
+{
+  Reading from multiple sockets
+  This version uses a simple recv loop
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program msread;
+
+uses SysUtils, zmq;
+
+var
+  context, receiver, subscriber: Pointer;
+  filter : string = '10001';
+
+  msg : array [0..255] of Char;
+  size: Integer;
+
+begin
+  //  Connect to task ventilator
+  context := zmq_ctx_new;
+  receiver := zmq_socket(context, ZMQ_PULL);
+  zmq_connect(receiver, 'tcp://localhost:5557');
+
+  //  Connect to weather server
+  subscriber := zmq_socket(context, ZMQ_SUB);
+  zmq_connect(subscriber, 'tcp://localhost:5556');
+  zmq_setsockopt(subscriber, ZMQ_SUBSCRIBE, @filter[1], Length(filter));
+
+  //  Process messages from both sockets
+  //  We prioritize traffic from the task ventilator
+  repeat
+    FillChar(msg, SizeOf(msg), 0);
+    repeat
+      size := zmq_recv(receiver, @msg, 255, ZMQ_DONTWAIT);
+      // Process task
+    until size = -1;
+
+    repeat
+      size := zmq_recv(subscriber, @msg, 255, ZMQ_DONTWAIT);
+      // Process weather update
+    until size = -1;
+
+    //  No activity, so sleep for 1 msec
+    Sleep(1);
+  until False;
+  zmq_close(receiver);
+  zmq_close(subscriber);
+  zmq_ctx_destroy (context);
+end.
+

--- a/examples/Free Pascal/rrbroker.pas
+++ b/examples/Free Pascal/rrbroker.pas
@@ -1,0 +1,78 @@
+{
+  Simple request-reply broker
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program rrbroker;
+
+{$mode objfpc}{$H+}
+
+uses SysUtils, zmq, zmq.helpers;
+
+const
+  forever = False;
+
+var
+  context, frontend, backend: Pointer;
+  items : array [0..1] of zmq_pollitem_t;
+
+  message : zmq_msg_t;
+  more : integer;
+begin
+  //  Prepare our context and sockets
+  context  := zmq_ctx_new;
+  frontend := zmq_socket(context, ZMQ_ROUTER);
+  backend  := zmq_socket(context, ZMQ_DEALER);
+  zmq_bind(frontend, 'tcp://*:5559');
+  zmq_bind(backend,  'tcp://*:5560');
+
+  //  Initialize poll array
+  with items[0] do
+    begin
+      socket := frontend;
+      fd := 0;
+      events := ZMQ_POLLIN;
+      revents := 0;
+    end;
+  with items[1] do
+    begin
+      socket := backend;
+      fd := 0;
+      events := ZMQ_POLLIN;
+      revents := 0;
+    end;
+
+  //  Switch messages between sockets
+  repeat
+    message := Default(zmq_msg_t);
+    zmq_poll(items[0], 2, -1);
+    if (items[0].revents and ZMQ_POLLIN) > 0 then
+      repeat
+        //  Process all parts of the message
+        zmq_msg_init(message);
+        zmq_msg_recv(message, frontend, 0);
+        more := zmq_msg_more(message);
+        if more = 0 then { do nothing } else more := ZMQ_SNDMORE;
+        zmq_msg_send(message, backend, more);
+        zmq_msg_close(message);
+        if more = 0 then break; //  Last message part
+      until forever;
+
+    if (items[1].revents and ZMQ_POLLIN) > 0 then
+      repeat
+        //  Process all parts of the message
+        zmq_msg_init(message);
+        zmq_msg_recv(message, backend, 0);
+        more := zmq_msg_more(message);
+        if more = 0 then { do nothing } else more := ZMQ_SNDMORE;
+        zmq_msg_send(message, frontend, more);
+        zmq_msg_close(message);
+        if more = 0 then break; //  Last message part
+      until forever;
+  until forever;
+
+  //  We never get here, but clean up anyhow
+  zmq_close(frontend);
+  zmq_close(backend);
+  zmq_ctx_destroy(context);
+end.
+

--- a/examples/Free Pascal/rrclient.pas
+++ b/examples/Free Pascal/rrclient.pas
@@ -1,0 +1,33 @@
+{
+  Hello World client
+  Connects REQ socket to tcp://localhost:5559
+  Sends "Hello" to server, expects "World" back
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program rrclient;
+
+{$mode objfpc}{$H+}
+
+uses SysUtils, zmq, zmq.helpers, zmq.types;
+
+var
+  context, requester: Pointer;
+  request_nbr: Integer;
+  LString: string;
+begin
+    context := zmq_ctx_new;
+
+    //  Socket to talk to server
+    requester := zmq_socket(context, ZMQ_REQ);
+    zmq_connect(requester, 'tcp://localhost:5559');
+    for request_nbr := 0 to 9 do
+      begin
+        s_send(requester, 'Hello');
+        LString := s_recv(requester);
+        WriteLn(Format('Received reply %d [%s]', [request_nbr, LString]));
+        LString := '';
+      end;
+    zmq_close(requester);
+    zmq_ctx_destroy(context);
+end.
+

--- a/examples/Free Pascal/rrworker.pas
+++ b/examples/Free Pascal/rrworker.pas
@@ -1,0 +1,38 @@
+{
+  Hello World worker
+  Connects REP socket to tcp://localhost:5560
+  Expects "Hello" from client, replies with "World"
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program rrworker;
+
+{$mode objfpc}{$H+}
+
+uses SysUtils, zmq, zmq.helpers;
+
+var
+  context, responder: Pointer;
+  LString: string;
+begin
+  context := zmq_ctx_new;
+
+  //  Socket to talk to clients
+  responder := zmq_socket(context, ZMQ_REP);
+  zmq_connect(responder, 'tcp://localhost:5560');
+  repeat
+    //  Wait for next request from client
+    LString := s_recv(responder);
+    WriteLn(Format('Received request: [%s]', [LString]));
+    LString := '';
+
+    //  Do some 'work'
+    Sleep(1);
+
+    //  Send reply back to client
+    s_send(responder, 'World');
+  until False;
+  //  We never get here, but clean up anyhow
+  zmq_close(responder);
+  zmq_ctx_destroy(context);
+end.
+

--- a/examples/Free Pascal/rtdealer.pas
+++ b/examples/Free Pascal/rtdealer.pas
@@ -1,0 +1,99 @@
+{
+  ROUTER-to-DEALER example
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program rtdealer;
+
+{$mode objfpc}{$H+}{$COPERATORS ON}
+
+uses
+  {$IFDEF UNIX}cthreads, cmem{$ENDIF}, SysUtils,
+  zmq, zmq.helpers;
+
+function worker_task(args : Pointer):PtrInt;
+var
+  context, worker: Pointer;
+  workload : string;
+  total: Integer;
+begin
+  context := zmq_ctx_new;
+  worker := zmq_socket(context, ZMQ_DEALER);
+{$IFDEF Win32}
+  s_set_id(worker, PrtInt(args));
+{$ELSE}
+  s_set_id(worker);          //  Set a printable identity.
+{$ENDIF}
+
+  zmq_connect(worker, 'tcp://localhost:5671');
+
+  total := 0;
+  repeat // WriteLn(ThreadID);
+    //  Tell the broker we're ready for work
+    s_sendmore(worker, '');
+    s_send(worker, 'Hi Boss');
+
+    //  Get workload from broker, until finished
+    s_recv(worker);
+    workload := s_recv(worker);
+    if workload = 'Fired!' then
+    begin
+      WriteLn(Format('Completed: %d tasks', [total]));
+      break;
+    end;
+    workload := '';
+    total += 1;
+    //  Do some random work
+    Sleep(randof(500) + 1);
+  until False;
+  zmq_close(worker);
+  zmq_ctx_destroy(context);
+  Result := PtrInt(0);
+end;
+
+//  While this example runs in a single process, that is only to make
+//  it easier to start and stop the example. Each thread has its own
+//  context and conceptually acts as a separate process.
+
+const NBR_WORKERS = 10;
+
+var
+  context, broker: Pointer;
+  worker_nbr, workers_fired: Integer;
+
+  identity : string;
+  end_time: LongWord;
+begin
+    context := zmq_ctx_new;
+    broker := zmq_socket(context, ZMQ_ROUTER);
+
+    zmq_bind(broker, 'tcp://*:5671');
+    Randomize;
+
+    for worker_nbr := 0 to NBR_WORKERS -1 do
+      BeginThread(@worker_task, @worker_nbr);
+
+    //  Run for five seconds and then tell workers to end
+    end_time := GetTickCount64 + 5000;
+    workers_fired := 0;
+    repeat
+      //  Next message gives us least recently used worker
+      identity := s_recv(broker);
+      s_sendmore(broker, identity);
+      identity := '';
+      s_recv(broker);     //  Envelope delimiter
+      s_recv(broker);     //  Response from worker
+      s_sendmore(broker, '');
+
+      //  Encourage workers until it's time to fire them
+      if (GetTickCount64 < end_time) then
+        s_send(broker, 'Work harder')
+      else
+      begin
+        s_send(broker, 'Fired!');
+        workers_fired += 1;
+        if workers_fired = NBR_WORKERS then break;
+      end;
+    until False;
+    zmq_close(broker);
+    zmq_ctx_destroy(context);
+end.

--- a/examples/Free Pascal/rtreq.pas
+++ b/examples/Free Pascal/rtreq.pas
@@ -1,0 +1,97 @@
+{
+  ROUTER-to-REQ example
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program rtreq;
+
+{$mode objfpc}{$H+}{$COPERATORS ON}
+
+uses
+  {$IFDEF UNIX}cthreads, cmem{$ENDIF}, SysUtils,
+  zmq, zmq.helpers;
+
+function worker_task(args : Pointer):PtrInt;
+var
+  context, worker: Pointer;
+  workload : string;
+  total: Integer;
+begin
+  context := zmq_ctx_new;
+  worker := zmq_socket(context, ZMQ_REQ);
+{$IFDEF Win32}
+  s_set_id(worker, PrtInt(args));
+{$ELSE}
+  s_set_id(worker);          //  Set a printable identity.
+{$ENDIF}
+
+  zmq_connect(worker, 'tcp://localhost:5671');
+
+  total := 0;
+  repeat // WriteLn(ThreadID);
+    //  Tell the broker we're ready for work
+    s_send(worker, 'Hi Boss');
+
+    //  Get workload from broker, until finished
+    workload := s_recv(worker);
+    if workload = 'Fired!' then
+    begin
+      WriteLn(Format('Completed: %d tasks', [total]));
+      break;
+    end;
+    workload := '';
+    total += 1;
+    //  Do some random work
+    Sleep(randof(500) + 1);
+  until False;
+  zmq_close(worker);
+  zmq_ctx_destroy(context);
+  Result := PtrInt(0);
+end;
+
+//  While this example runs in a single process, that is only to make
+//  it easier to start and stop the example. Each thread has its own
+//  context and conceptually acts as a separate process.
+
+const NBR_WORKERS = 10;
+
+var
+  context, broker: Pointer;
+  worker_nbr, workers_fired: Integer;
+
+  identity : string;
+  end_time: LongWord;
+begin
+    context := zmq_ctx_new;
+    broker := zmq_socket(context, ZMQ_ROUTER);
+
+    zmq_bind(broker, 'tcp://*:5671');
+    Randomize;
+
+    for worker_nbr := 0 to NBR_WORKERS -1 do
+      BeginThread(@worker_task, @worker_nbr);
+
+    //  Run for five seconds and then tell workers to end
+    end_time := GetTickCount64 + 5000;
+    workers_fired := 0;
+    repeat
+      //  Next message gives us least recently used worker
+      identity := s_recv(broker);
+      s_sendmore(broker, identity);
+      identity := '';
+      s_recv(broker);     //  Envelope delimiter
+      s_recv(broker);     //  Response from worker
+      s_sendmore(broker, '');
+
+      //  Encourage workers until it's time to fire them
+      if (GetTickCount64 < end_time) then
+        s_send(broker, 'Work harder')
+      else
+      begin
+        s_send(broker, 'Fired!');
+        workers_fired += 1;
+        if workers_fired = NBR_WORKERS then break;
+      end;
+    until False;
+    zmq_close(broker);
+    zmq_ctx_destroy(context);
+end.

--- a/examples/Free Pascal/tasksink.pas
+++ b/examples/Free Pascal/tasksink.pas
@@ -1,0 +1,51 @@
+{
+  Task sink
+  Binds PULL socket to tcp://localhost:5558
+  Collects results from workers via that socket
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program tasksink;
+
+{$MODE objfpc}{$H+}
+
+uses SysUtils, zmq, zmq.helpers, zmq.types;
+
+var
+  context, receiver: Pointer;
+  LString: string;
+  start_time: LongWord;
+  task_nbr: Integer;
+
+begin
+  //  Prepare our context and socket
+  context := zmq_ctx_new;
+  receiver := zmq_socket(context, ZMQ_PULL);
+  zmq_bind(receiver, 'tcp://*:5558');
+
+  //  Wait for start of batch
+  LString := s_recv(receiver);
+  LString := '';
+
+  //  Start our clock now
+  start_time := GettickCount64;
+
+  //  Process 100 confirmations
+  for task_nbr := 0 to 100 -1 do
+  begin
+    LString := s_recv(receiver);
+    LString := '';
+    if ((task_nbr / 10) * 10 = task_nbr) then
+      Write(':')
+    else
+      Write('.');
+    // Flush(output);
+  end;
+
+  //  Calculate and report duration of batch
+  WriteLn(Format('Total elapsed time: %d msec',
+    [GettickCount64 - start_time]));
+
+  zmq_close(receiver);
+  zmq_ctx_destroy(context);
+end.
+

--- a/examples/Free Pascal/tasksink2.pas
+++ b/examples/Free Pascal/tasksink2.pas
@@ -1,0 +1,54 @@
+{
+  Task sink - design 2
+  Adds pub-sub flow to send kill signal to workers
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program tasksink2;
+
+{$mode objfpc}{$H+}
+
+uses SysUtils, zmq, zmq.helpers;
+
+var
+  context, receiver, controller: Pointer;
+  LString : string;
+  task_nbr: Integer;
+  start_time: QWord;
+begin
+  //  Socket to receive messages on
+  context := zmq_ctx_new;
+  receiver := zmq_socket(context, ZMQ_PULL);
+  zmq_bind(receiver, 'tcp://*:5558');
+
+  //  Socket for worker control
+  controller := zmq_socket(context, ZMQ_PUB);
+  zmq_bind(controller, 'tcp://*:5559');
+
+  //  Wait for start of batch
+  LString := s_recv(receiver);
+  LString := '';
+
+  //  Start our clock now
+  start_time := GetTickCount64;
+
+  //  Process 100 confirmations
+  for task_nbr := 0 to 99 do
+    begin
+      LString := s_recv(receiver);
+      LString := '';
+      if (task_nbr mod 10) = 0 then
+        Write(':')
+      else
+        Write('.');
+      Flush(StdOut);
+    end;
+  WriteLn(Format('Total elapsed time: %d msec',
+      [GetTickCount64 - start_time]));
+
+  //  Send kill signal to workers
+  s_send(controller, 'KILL');
+
+  zmq_close(receiver);
+  zmq_close(controller);
+  zmq_ctx_destroy(context);
+end.

--- a/examples/Free Pascal/taskvent.pas
+++ b/examples/Free Pascal/taskvent.pas
@@ -1,0 +1,57 @@
+{
+  Task ventilator
+  Binds PUSH socket to tcp://localhost:5557
+  Sends batch of tasks to workers via that socket
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program taskvent;
+
+{$MODE objfpc}{$H+}{$COPERATORS ON}
+
+uses SysUtils, zmq, zmq.helpers;
+
+var
+  context, sender, sink : Pointer;
+  task_nbr : integer;
+  total_msec : integer = 0; //  Total expected cost in msecs
+  workload : integer;
+
+  LString : string;
+begin
+  context := zmq_ctx_new;
+
+  //  Socket to send messages on
+  sender := zmq_socket(context, ZMQ_PUSH);
+  zmq_bind(sender, 'tcp://*:5557');
+
+  //  Socket to send start of batch message on
+  sink := zmq_socket(context, ZMQ_PUSH);
+  zmq_connect(sink, 'tcp://localhost:5558');
+
+  WriteLn('Press Enter when the workers are ready: ');
+  ReadLn;
+  WriteLn('Sending tasks to workers…');
+
+  //  The first message is "0" and signals start of batch
+  s_send(sink, '0');
+
+  //  Initialize random number generator
+  Randomize;
+
+  //  Send 100 tasks
+  for task_nbr := 0 to 100 -1 do
+    begin
+      //  Random workload from 1 to 100msecs
+      workload := randof(100) + 1;
+      total_msec += workload;
+      LString := IntToStr(workload);
+      s_send(sender, LString);
+    end;
+
+  WriteLn(Format('Total expected cost: %d msec', [total_msec]));
+
+  zmq_close(sink);
+  zmq_close(sender);
+  zmq_ctx_destroy(context);
+end.
+

--- a/examples/Free Pascal/taskwork.pas
+++ b/examples/Free Pascal/taskwork.pas
@@ -1,0 +1,42 @@
+{
+  Task worker
+  Connects PULL socket to tcp://localhost:5557
+  Collects workloads from ventilator via that socket
+  Connects PUSH socket to tcp://localhost:5558
+  Sends results to sink via that socket
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program taskwork;
+
+{$MODE objfpc}{$H+}
+
+uses sysutils, zmq, zmq.helpers;
+
+var
+  context, receiver, sender: Pointer;
+  LString : string;
+begin
+  //  Socket to receive messages on
+  context := zmq_ctx_new;
+  receiver := zmq_socket(context, ZMQ_PULL);
+  zmq_connect(receiver, 'tcp://localhost:5557');
+
+  //  Socket to send messages to
+  sender := zmq_socket(context, ZMQ_PUSH);
+  zmq_connect(sender, 'tcp://localhost:5558');
+
+  //  Process tasks forever
+  repeat
+    LString := s_recv(receiver);
+    Write(LString+'.');     //  Show progress
+    // Flush(output);
+    Sleep(StrToInt(LString));  //  Do the work
+    LString := '';
+    s_send(sender, '');        //  Send results to sink
+  until False;
+
+  zmq_close(receiver);
+  zmq_close(sender);
+  zmq_ctx_destroy(context);
+end.
+

--- a/examples/Free Pascal/taskwork2.pas
+++ b/examples/Free Pascal/taskwork2.pas
@@ -1,0 +1,55 @@
+{
+  Task sink - design 2
+  Adds pub-sub flow to send kill signal to workers
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program taskwork2;
+
+{$mode objfpc}{$H+}
+
+uses SysUtils, zmq, zmq.helpers;
+
+var
+  context, receiver, controller: Pointer;
+  LString : string;
+  task_nbr: Integer;
+  start_time: QWord;
+begin
+  //  Socket to receive messages on
+  context := zmq_ctx_new;
+  receiver := zmq_socket(context, ZMQ_PULL);
+  zmq_bind(receiver, 'tcp://*:5558');
+
+  //  Socket for worker control
+  controller := zmq_socket(context, ZMQ_PUB);
+  zmq_bind(controller, 'tcp://*:5559');
+
+  //  Wait for start of batch
+  LString := s_recv(receiver);
+  LString := '';
+
+  //  Start our clock now
+  start_time := GetTickCount64;
+
+  //  Process 100 confirmations
+  task_nbr := 0;
+  for task_nbr := 0 to 99 do
+  begin
+    LString := s_recv(receiver);
+    LString := '';
+    if ((task_nbr mod 10) = 0) then
+      WriteLn(':')
+    else
+      WriteLn('.');
+    //Flush(StdOut);
+  end;
+  WriteLn(Format('Total elapsed time: %d msec',
+    [GetTickCount64 - start_time]));
+
+  //  Send kill signal to workers
+  s_send(controller, 'KILL');
+
+  zmq_close(receiver);
+  zmq_close(controller);
+  zmq_ctx_destroy(context);
+end.

--- a/examples/Free Pascal/wuclient.pas
+++ b/examples/Free Pascal/wuclient.pas
@@ -55,3 +55,4 @@ begin
   zmq_close(subscriber);
   zmq_ctx_destroy(context);
 end.
+

--- a/examples/Free Pascal/wuclient.pas
+++ b/examples/Free Pascal/wuclient.pas
@@ -1,0 +1,57 @@
+{
+  Weather update client
+  Connects SUB socket to tcp://localhost:5556
+  Collects weather updates and finds avg temp in zipcode
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program wuclient;
+
+{$MODE objfpc}{$H+}{$COPERATORS ON}
+
+uses SysUtils, zmq, zmq.helpers;
+
+var
+  context : Pointer;
+  subscriber : Pointer;
+  rc: Integer;
+  filter : string;
+
+  update_nbr : Integer;
+  total_temp : LongInt = 0;
+  total_humid : LongInt = 0;
+
+  LString : shortstring;
+  zipcode, temperature, relhumidity : integer;
+begin
+  //  Socket to talk to server
+  WriteLn('Collecting updates from weather server…');
+  context := zmq_ctx_new;
+  subscriber := zmq_socket(context, ZMQ_SUB);
+  rc := zmq_connect(subscriber, 'tcp://localhost:5556');
+  Assert(rc = 0);
+
+  //  Subscribe to zipcode, default is NYC, 10001
+  if ParamCount > 1 then filter := ParamStr(1) else filter := '10001';
+  rc := zmq_setsockopt(subscriber, ZMQ_SUBSCRIBE, @filter[1], Length(filter));
+  Assert(rc = 0);
+
+  //  Process 100 updates
+  for update_nbr := 0 to 100 -1 do
+    begin
+      LString := s_recv(subscriber);
+      ReadStr(LString, zipcode, temperature, relhumidity);
+      total_temp += temperature;
+      total_humid += relhumidity;
+      LString := '';
+    end;
+  update_nbr += 1;
+
+  WriteLn(Format('Average temperature for zipcode %s was %.2f',
+    [filter, total_temp/update_nbr]));
+
+  WriteLn(Format('Average relative humidity for zipcode %s was %.2f',
+    [filter, total_humid/update_nbr]));
+
+  zmq_close(subscriber);
+  zmq_ctx_destroy(context);
+end.

--- a/examples/Free Pascal/wuproxy.pas
+++ b/examples/Free Pascal/wuproxy.pas
@@ -1,0 +1,32 @@
+{
+  Weather proxy device
+  Same as request-reply broker but using shared queue proxy
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program wuproxy;
+
+{$mode objfpc}{$H+}
+
+uses zmq;
+
+var
+  context, frontend, backend: Pointer;
+begin
+  context := zmq_ctx_new;
+
+  //  This is where the weather server sits
+  frontend := zmq_socket(context, ZMQ_XSUB);
+  zmq_connect(frontend, 'tcp://192.168.55.210:5556');
+
+  //  This is our public endpoint for subscribers
+  backend := zmq_socket(context, ZMQ_XPUB);
+  zmq_bind(backend, 'tcp://10.1.1.0:8100');
+
+  //  Run the proxy until the user interrupts us
+  zmq_proxy(frontend, backend, nil);
+
+  zmq_close(frontend);
+  zmq_close(backend);
+  zmq_ctx_destroy (context);
+end.
+

--- a/examples/Free Pascal/wuserver.pas
+++ b/examples/Free Pascal/wuserver.pas
@@ -1,0 +1,44 @@
+{
+  Weather update server
+  Binds PUB socket to tcp://*:5556
+  Publishes random weather updates
+  @author cpicanco <cpicanco@ufpa.br>
+}
+program wuserver;
+
+{$MODE objfpc}{$H+}
+
+uses SysUtils, zmq, zmq.helpers;
+
+var
+  context : Pointer;
+  publisher : Pointer;
+  rc : integer;
+
+  zipcode, temperature, relhumidity : integer;
+  update : string[20];
+
+begin
+  //  Prepare our context and publisher
+  context := zmq_ctx_new;
+  publisher := zmq_socket(context, ZMQ_PUB);
+  rc := zmq_bind(publisher, 'tcp://*:5556');
+  Assert(rc = 0);
+
+  //  Initialize random number generator
+  Randomize;
+  repeat
+    //  Get values that will fool the boss
+    zipcode     := RandOf(100000);
+    temperature := RandOf(215) - 80;
+    relhumidity := RandOf(50) + 10;
+
+    //  Send message to all subscribers
+    WriteStr(update, Format('%5d %d %d', [zipcode, temperature, relhumidity]));
+    s_send(publisher, update);
+  until False;
+
+  zmq_close(publisher);
+  zmq_ctx_destroy(context);
+end.
+

--- a/examples/Free Pascal/zmq.helpers.pas
+++ b/examples/Free Pascal/zmq.helpers.pas
@@ -1,0 +1,228 @@
+{
+  fpc-zmq
+  Copyright (C) 2017 Carlos Rafael Fernandes Picanço.
+
+  The present file is distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+}
+unit zmq.helpers;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, zmq.types;
+
+  // Receive 0MQ string from socket and convert into ShortString
+  // Caller must free returned string. Returns NULL if the context
+  // is being terminated.
+  function RecvShortString(Socket: Pointer): String;
+
+  // Convert Shortstring to 0MQ string and send to socket
+  function SendString(Socket: Pointer; const AString: String): integer;
+
+  // Sends string as 0MQ string, as multipart non-terminal
+  function SendMoreString(Socket: Pointer; const AString: String): integer;
+
+  // Receives all message parts from socket, prints neatly
+  procedure Dump(Socket: Pointer);
+
+
+  procedure RecvMultiPartString(Socket: Pointer; AStringList : TStringList); inline;
+  procedure SendMultiPartString(Socket: Pointer; constref AMultiPart : array of string); overload; inline;
+  procedure SendMultiPartString(Socket: Pointer; const AStringList : TStringList); overload; inline;
+
+{$IFDEF Win32}
+  //  Set simple random printable identity on socket
+  procedure SetID(Socket : Pointer; id : PtrInt);
+{$ELSE}
+  //  Set simple random printable identity on socket
+  //  Caution:
+  //    DO NOT call this version of s_set_id from multiple threads on MS Windows
+  //    since s_set_id will call rand() on MS Windows. rand(), however, is not
+  //    reentrant or thread-safe. See issue #521.
+  procedure SetID(Socket: Pointer);
+{$ENDIF}
+
+
+var
+  RandOf : TRandOf; // Provide random number from 0..(num-1)
+
+  // Receive 0MQ string from socket and convert into ShortString
+  // Caller must free returned string. Returns NULL if the context
+  // is being terminated.
+  s_recv : TZMQRecvStringFunction;
+  s_send : TZMQSendStringFunction; // Convert Shortstring to 0MQ string and send to socket
+  s_sendmore : TZMQSendStringFunction; // Sends string as 0MQ string, as multipart non-terminal
+  s_dump : TZMQSocketProcedure; // Receives all message parts from socket, prints neatly
+{$IFDEF Win32}
+  s_set_id : TZMQSetIDProcedure; //  Set simple random printable identity on socket
+{$ELSE}
+  s_set_id : TZMQSocketProcedure; //  Set simple random printable identity on socket
+{$ENDIF}
+
+
+implementation
+
+uses zmq, LazUTF8;
+
+function RecvShortString(Socket: Pointer): String;
+var
+  buffer : array [0..High(ShortString)] of Byte;
+  size : integer;
+begin
+  Result := '';
+  size := zmq_recv(Socket, @buffer, High(buffer), 0);
+  if size = -1 then exit;
+  buffer[size] := $00;
+  SetString(Result, PAnsiChar(@buffer), size);
+end;
+
+procedure RecvMultiPartString(Socket: Pointer; AStringList : TStringList);
+var
+  zmq_message : zmq_msg_t;
+
+  procedure RecvMessage; inline;
+  var message : string = '';
+  begin
+    zmq_msg_init(zmq_message);
+    zmq_msg_recv(zmq_message, Socket, 0);
+    SetString(message, PAnsiChar(zmq_msg_data(zmq_message)), zmq_msg_size(zmq_message));
+    AStringList.Append(message);
+  end;
+begin
+  zmq_message := Default(zmq_msg_t);
+  AStringList.BeginUpdate;
+  RecvMessage;
+  while zmq_msg_more(zmq_message) = 1 do
+  begin
+    zmq_msg_close(zmq_message);
+    RecvMessage;
+  end;
+  zmq_msg_close(zmq_message);
+  AStringList.EndUpdate;
+end;
+
+procedure SendMultiPartString(Socket: Pointer; constref AMultiPart: array of string);
+var
+  i: Integer;
+begin
+  case Length(AMultiPart) of
+    0 : zmq_send(Socket, nil, 0, 0);
+    1 : zmq_send(Socket, @AMultiPart[0][1],Length(AMultiPart[0]), 0);
+    else
+      begin
+        for i := Low(AMultiPart) to High(AMultiPart)-1 do
+          SendMoreString(Socket, AMultiPart[i]);
+        SendString(Socket, AMultiPart[i+1]);
+      end;
+  end;
+end;
+
+procedure SendMultiPartString(Socket: Pointer; const AStringList: TStringList);
+var
+  i: Integer;
+begin
+  case AStringList.Count of
+    0 : zmq_send(Socket, nil, 0, 0);
+    1 : zmq_send(Socket, @AStringList[0][1],Length(AStringList[0]), 0);
+    else
+      begin
+        for i := 0 to AStringList.Count -2 do
+          SendMoreString(Socket, AStringList[i]);
+        SendString(Socket, AStringList[i+1]);
+      end;
+  end;
+end;
+
+function SendString(Socket: Pointer; const AString: String): integer;
+begin
+  if AString = '' then
+    Result := zmq_send(Socket, nil, 0, 0)
+  else
+    Result := zmq_send(Socket, @AString[1], Length(AString), 0);
+end;
+
+function SendMoreString(Socket: Pointer; const  AString: String): integer;
+begin
+  if AString = '' then
+    Result := zmq_send(Socket, nil, 0, ZMQ_SNDMORE)
+  else
+    Result := zmq_send(Socket, @AString[1], Length(AString), ZMQ_SNDMORE);
+end;
+
+{$IFDEF Win32}
+//  Set simple random printable identity on socket
+procedure SetID(Socket : Pointer; id : PtrInt);
+var identity : string[10];
+begin
+  WriteStr(identity,Format('%04X',[Integer(id)]));
+  zmq_setsockopt(socket, ZMQ_IDENTITY, @identity[1], Length(identity));
+end;
+{$ELSE}
+procedure SetID(Socket: Pointer);
+var identity : string[10];
+begin
+  WriteStr(identity,Format('%04X-%04X',[Random($10000), Random($10000)]));
+  zmq_setsockopt(socket, ZMQ_IDENTITY, @identity[1], Length(identity));
+end;
+{$ENDIF}
+
+procedure Dump(Socket: Pointer);
+var
+  rc : integer = -1;
+  message : zmq_msg_t;
+
+  size : integer = 0;
+  data : PChar;
+
+  is_text : Boolean;
+  char_nbr : integer;
+begin
+  rc := zmq_msg_init(message);
+  Assert(rc = 0);
+
+  WriteLn('----------------------------------------');
+  //  Process all parts of the message
+
+  repeat
+    size := zmq_msg_recv(message, Socket, 0);
+    Assert(size >= 0);
+
+    //  Dump the message as text or binary
+    data := zmq_msg_data(message);
+    Assert(data <> nil);
+    is_text := True;
+    for char_nbr := 0 to size -1 do
+      if   (Ord(data[char_nbr]) < 32)
+        or (Ord(data[char_nbr]) > 126)
+      then is_text := False;
+
+    Write(Format('[%.3d]',[size]),#32);
+    for char_nbr := 0 to size -1 do
+      if is_text then
+        Write(data[char_nbr])
+      else
+        Write(Format('%x',[Byte(data[char_nbr])]),#32);
+
+    Write(LineEnding);
+  until zmq_msg_more(message) = 0;
+
+  rc := zmq_msg_close(message);
+  Assert(rc = 0);
+end;
+
+initialization
+  RandOf := @Random;
+  s_recv := @RecvShortString;
+  s_send := @SendString;
+  s_sendmore := @SendMoreString;
+  s_dump := @Dump;
+  s_set_id := @SetID;
+
+finalization
+
+end.

--- a/examples/Free Pascal/zmq.pas
+++ b/examples/Free Pascal/zmq.pas
@@ -1,0 +1,669 @@
+{
+  fpc-zmq
+  Copyright (C) 2017 Carlos Rafael Fernandes Picanço.
+
+  The present file is distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+}
+unit zmq; // https://github.com/zeromq/libzmq/commit/f1c72dc8e5a92c32013a07d8aee68deee70adf8a
+
+{$mode objfpc}{$H+}
+
+{$IFDEF LINUX}
+  {$LINKLIB pthread}
+  {$IFDEF ZMQ_STATIC_LINK}
+    {$LINKLIB m}
+    {$LINKLIB stdc++}
+    {$LINKLIB gcc_s}
+    {$LINKLIB zmq.a} // /usr/local/lib/libzmq.a
+  {$ENDIF}
+{$ENDIF}
+
+{$IFDEF WINDOWS}
+  {$IFDEF ZMQ_STATIC_LINK}
+    // libzmq.lib
+    // implement me
+  {$ENDIF}
+{$ENDIF}
+
+{$IFDEF DARWIN}
+  {$IFDEF ZMQ_STATIC_LINK}
+    // libzmq.a
+    // implement me
+  {$ENDIF}
+{$ENDIF}
+
+{$IFDEF ANDROID}
+  {$IFDEF ZMQ_STATIC_LINK}
+    // libzmq.a
+    // implement me
+  {$ENDIF}
+{$ENDIF}
+
+interface
+
+{$IFNDEF ZMQ_STATIC_LINK}
+const
+  {$ifdef LINUX}
+  libzmq = 'zmq';
+  {$ENDIF}
+
+  {$IFDEF WINDOWS}
+  libzmq = 'libzmq.dll';
+  {$ENDIF}
+
+  {$IFDEF DARWIN}
+  libzmq = 'libzmq.dylib';
+  {$ENDIF}
+  
+  {$ifdef ANDROID}
+  libzmq = 'libzmq.so';
+  {$ENDIF}
+  
+{$ENDIF}
+
+{
+  /*  Define integer types needed for event interface                          */
+}
+const
+  ZMQ_DEFINED_STDINT = 1;
+
+{
+  /******************************************************************************/
+  /*  0MQ errors.                                                               */
+  /******************************************************************************/
+
+  /*  A number random enough not to collide with different errno ranges on      */
+  /*  different OSes. The assumption is that error_t is at least 32-bit type.   */
+}
+
+  ZMQ_HAUSNUMERO = 156384712;
+
+{
+  /*  On Windows platform some of the standard POSIX errnos are not defined.    */
+}
+
+  ENOTSUP = ZMQ_HAUSNUMERO + 1;
+  EPROTONOSUPPORT = ZMQ_HAUSNUMERO + 2;
+  ENOBUFS = ZMQ_HAUSNUMERO + 3;
+  ENETDOWN = ZMQ_HAUSNUMERO + 4;
+  EADDRINUSE = ZMQ_HAUSNUMERO + 5;
+  EADDRNOTAVAIL = ZMQ_HAUSNUMERO + 6;
+  ECONNREFUSED = ZMQ_HAUSNUMERO + 7;
+  EINPROGRESS = ZMQ_HAUSNUMERO + 8;
+  ENOTSOCK = ZMQ_HAUSNUMERO + 9;
+  EMSGSIZE = ZMQ_HAUSNUMERO + 10;
+  EAFNOSUPPORT = ZMQ_HAUSNUMERO + 11;
+  ENETUNREACH = ZMQ_HAUSNUMERO + 12;
+  ECONNABORTED = ZMQ_HAUSNUMERO + 13;
+  ECONNRESET = ZMQ_HAUSNUMERO + 14;
+  ENOTCONN = ZMQ_HAUSNUMERO + 15;
+  ETIMEDOUT = ZMQ_HAUSNUMERO + 16;
+  EHOSTUNREACH = ZMQ_HAUSNUMERO + 17;
+  ENETRESET = ZMQ_HAUSNUMERO + 18;
+
+{
+  /*  Native 0MQ error codes.                                                   */
+}
+
+  EFSM = ZMQ_HAUSNUMERO + 51;
+  ENOCOMPATPROTO = ZMQ_HAUSNUMERO + 52;
+  ETERM = ZMQ_HAUSNUMERO + 53;
+  EMTHREAD = ZMQ_HAUSNUMERO + 54;
+
+{
+  /*  This function retrieves the errno as it is known to 0MQ library. The goal */
+  /*  of this function is to make the code 100% portable, including where 0MQ   */
+  /*  compiled with certain CRT library (on Windows) is linked to an            */
+  /*  application that uses different CRT library.                              */
+}
+function zmq_errno: integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+{
+  /*  Resolves system errors and 0MQ errors to human-readable string.           */
+}
+function zmq_strerror(errnum: integer):PChar; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+{
+  /* Run-time API version detection                                             */
+}
+procedure zmq_version(out major: integer; out minor: integer; out patch: integer); cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+{
+  /******************************************************************************/
+  /*  0MQ infrastructure (a.k.a. context) initialisation & termination.         */
+  /******************************************************************************/
+
+  /*  Context options                                                           */
+}
+const
+
+ZMQ_IO_THREADS  = 1;
+ZMQ_MAX_SOCKETS = 2;
+ZMQ_SOCKET_LIMIT = 3;
+ZMQ_THREAD_PRIORITY = 3;
+ZMQ_THREAD_SCHED_POLICY = 4;
+ZMQ_MAX_MSGSZ = 5;
+
+{
+  /*  Default for new contexts                                                  */
+}
+
+ZMQ_IO_THREADS_DFLT  = 1;
+ZMQ_MAX_SOCKETS_DFLT = 1023;
+ZMQ_THREAD_PRIORITY_DFLT = -1;
+ZMQ_THREAD_SCHED_POLICY_DFLT = -1;
+
+function zmq_ctx_new : Pointer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_ctx_term(context: Pointer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_ctx_shutdown(context: Pointer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_ctx_set(context: Pointer; option: integer; optval: integer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_ctx_get(context: Pointer; option: integer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+{
+  /*  Old (legacy) API                                                          */
+}
+
+function zmq_init(io_threads: integer) : Pointer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_term (context: Pointer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_ctx_destroy (context: Pointer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+//
+//  /******************************************************************************/
+//  /*  0MQ message definition.                                                   */
+//  /******************************************************************************/
+//
+//  /* Some architectures, like sparc64 and some variants of aarch64, enforce pointer
+//   * alignment and raise sigbus on violations. Make sure applications allocate
+//   * zmq_msg_t on addresses aligned on a pointer-size boundary to avoid this issue.
+//   */
+//
+
+// http://forum.lazarus.freepascal.org/index.php/topic,37739.0.html
+
+{$IFDEF ANDROID}
+  {$IFDEF ARM64}{$IFDEF CPU64}{$ALIGN 8}{$ENDIF}{$ENDIF}
+  {$IFDEF ARMV7VE}{$IFDEF CPU32}{$ALIGN 4}{$ENDIF}{$ENDIF}
+{$ENDIF}
+type zmq_msg_t = packed record
+  _ : array [0..64-1] of Byte;
+end;
+{$IFDEF ANDROID}
+  {$ALIGN OFF}
+{$ENDIF}
+
+// type Pzmq_msg_t = ^zmq_msg_t;
+
+type zmq_free_fn = procedure (data: Pointer; hint: pointer);
+
+function zmq_msg_init(out msg: zmq_msg_t) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_init_size(out msg: zmq_msg_t; size: LongWord) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_init_data(out msg: zmq_msg_t; data: Pointer;
+  size: LongWord; ffn : zmq_free_fn; hint : Pointer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_send(var msg: zmq_msg_t;  s: Pointer; flags: integer): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_recv(var msg: zmq_msg_t; s: Pointer; flags: integer): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_close(var msg: zmq_msg_t): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_move(var dest: zmq_msg_t; var src: zmq_msg_t): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_copy(var dest: zmq_msg_t; var src: zmq_msg_t): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_data(var msg: zmq_msg_t ) : Pointer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_size(var msg: zmq_msg_t) : LongWord; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_more(var msg: zmq_msg_t): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_get(var msg: zmq_msg_t; aproperty: integer): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_set(var msg: zmq_msg_t; aproperty: integer; optval: integer): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+function zmq_msg_gets(var msg: zmq_msg_t; const aproperty: PChar): PChar; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+{
+  /******************************************************************************/
+  /*  0MQ socket definition.                                                    */
+  /******************************************************************************/
+
+  /*  Socket types.                                                             */
+}
+const
+  ZMQ_PAIR = 0;
+  ZMQ_PUB = 1;
+  ZMQ_SUB = 2;
+  ZMQ_REQ = 3;
+  ZMQ_REP = 4;
+  ZMQ_DEALER = 5;
+  ZMQ_ROUTER = 6;
+  ZMQ_PULL = 7;
+  ZMQ_PUSH = 8;
+  ZMQ_XPUB = 9;
+  ZMQ_XSUB = 10;
+  ZMQ_STREAM = 11;
+
+{
+  /*  Deprecated aliases                                                        */
+}
+
+  ZMQ_XREQ = ZMQ_DEALER deprecated;
+  ZMQ_XREP = ZMQ_ROUTER deprecated;
+
+{
+  /*  Socket options.                                                           */
+}
+
+  ZMQ_AFFINITY = 4;
+  ZMQ_IDENTITY = 5;
+  ZMQ_SUBSCRIBE = 6;
+  ZMQ_UNSUBSCRIBE = 7;
+  ZMQ_RATE = 8;
+  ZMQ_RECOVERY_IVL = 9;
+  ZMQ_SNDBUF = 11;
+  ZMQ_RCVBUF = 12;
+  ZMQ_RCVMORE = 13;
+  ZMQ_FD = 14;
+  ZMQ_EVENTS = 15;
+  ZMQ_TYPE = 16;
+  ZMQ_LINGER = 17;
+  ZMQ_RECONNECT_IVL = 18;
+  ZMQ_BACKLOG = 19;
+  ZMQ_RECONNECT_IVL_MAX = 21;
+  ZMQ_MAXMSGSIZE = 22;
+  ZMQ_SNDHWM = 23;
+  ZMQ_RCVHWM = 24;
+  ZMQ_MULTICAST_HOPS = 25;
+  ZMQ_RCVTIMEO = 27;
+  ZMQ_SNDTIMEO = 28;
+  ZMQ_LAST_ENDPOINT = 32;
+  ZMQ_ROUTER_MANDATORY = 33;
+  ZMQ_TCP_KEEPALIVE = 34;
+  ZMQ_TCP_KEEPALIVE_CNT = 35;
+  ZMQ_TCP_KEEPALIVE_IDLE = 36;
+  ZMQ_TCP_KEEPALIVE_INTVL = 37;
+  ZMQ_IMMEDIATE = 39;
+  ZMQ_XPUB_VERBOSE = 40;
+  ZMQ_ROUTER_RAW = 41;
+  ZMQ_IPV6 = 42;
+  ZMQ_MECHANISM = 43;
+  ZMQ_PLAIN_SERVER = 44;
+  ZMQ_PLAIN_USERNAME = 45;
+  ZMQ_PLAIN_PASSWORD = 46;
+  ZMQ_CURVE_SERVER = 47;
+  ZMQ_CURVE_PUBLICKEY = 48;
+  ZMQ_CURVE_SECRETKEY = 49;
+  ZMQ_CURVE_SERVERKEY = 50;
+  ZMQ_PROBE_ROUTER = 51;
+  ZMQ_REQ_CORRELATE = 52;
+  ZMQ_REQ_RELAXED = 53;
+  ZMQ_CONFLATE = 54;
+  ZMQ_ZAP_DOMAIN = 55;
+  ZMQ_ROUTER_HANDOVER = 56;
+  ZMQ_TOS = 57;
+  ZMQ_CONNECT_RID = 61;
+  ZMQ_GSSAPI_SERVER = 62;
+  ZMQ_GSSAPI_PRINCIPAL = 63;
+  ZMQ_GSSAPI_SERVICE_PRINCIPAL = 64;
+  ZMQ_GSSAPI_PLAINTEXT = 65;
+  ZMQ_HANDSHAKE_IVL = 66;
+  ZMQ_SOCKS_PROXY = 68;
+  ZMQ_XPUB_NODROP = 69;
+  ZMQ_BLOCKY = 70;
+  ZMQ_XPUB_MANUAL = 71;
+  ZMQ_XPUB_WELCOME_MSG = 72;
+  ZMQ_STREAM_NOTIFY = 73;
+  ZMQ_INVERT_MATCHING = 74;
+  ZMQ_HEARTBEAT_IVL = 75;
+  ZMQ_HEARTBEAT_TTL = 76;
+  ZMQ_HEARTBEAT_TIMEOUT = 77;
+  ZMQ_XPUB_VERBOSER = 78;
+  ZMQ_CONNECT_TIMEOUT = 79;
+  ZMQ_TCP_MAXRT = 80;
+  ZMQ_THREAD_SAFE = 81;
+  ZMQ_MULTICAST_MAXTPDU = 84;
+  ZMQ_VMCI_BUFFER_SIZE = 85;
+  ZMQ_VMCI_BUFFER_MIN_SIZE = 86;
+  ZMQ_VMCI_BUFFER_MAX_SIZE = 87;
+  ZMQ_VMCI_CONNECT_TIMEOUT = 88;
+  ZMQ_USE_FD = 89;
+
+{
+  /*  Message options                                                           */
+}
+
+  ZMQ_MORE = 1;
+  ZMQ_SHARED = 3;
+
+{
+  /*  Send/recv options.                                                        */
+}
+
+  ZMQ_DONTWAIT = 1;
+  ZMQ_SNDMORE = 2;
+
+{
+  /*  Security mechanisms                                                       */
+}
+  ZMQ_NULL = 0;
+  ZMQ_PLAIN = 1;
+  ZMQ_CURVE = 2;
+  ZMQ_GSSAPI = 3;
+
+{
+  /*  RADIO-DISH protocol                                                       */
+}
+  ZMQ_GROUP_MAX_LENGTH = 15;
+
+{
+  /*  Deprecated options and aliases                                            */
+}
+
+  ZMQ_TCP_ACCEPT_FILTER       = 38 deprecated;
+  ZMQ_IPC_FILTER_PID          = 58 deprecated;
+  ZMQ_IPC_FILTER_UID          = 59 deprecated;
+  ZMQ_IPC_FILTER_GID          = 60 deprecated;
+  ZMQ_IPV4ONLY                = 31 deprecated;
+  ZMQ_DELAY_ATTACH_ON_CONNECT = ZMQ_IMMEDIATE deprecated;
+  ZMQ_NOBLOCK                 = ZMQ_DONTWAIT deprecated;
+  ZMQ_FAIL_UNROUTABLE         = ZMQ_ROUTER_MANDATORY deprecated;
+  ZMQ_ROUTER_BEHAVIOR         = ZMQ_ROUTER_MANDATORY deprecated;
+
+{
+  /*  Deprecated Message options                                                */
+}
+
+  ZMQ_SRCFD = 2 deprecated;
+
+
+{
+    /******************************************************************************/
+    /*  0MQ socket events and monitoring                                          */
+    /******************************************************************************/
+
+    /*  Socket transport events (TCP, IPC and TIPC only)                          */
+}
+  ZMQ_EVENT_CONNECTED       = $0001;
+  ZMQ_EVENT_CONNECT_DELAYED = $0002;
+  ZMQ_EVENT_CONNECT_RETRIED = $0004;
+  ZMQ_EVENT_LISTENING       = $0008;
+  ZMQ_EVENT_BIND_FAILED     = $0010;
+  ZMQ_EVENT_ACCEPTED        = $0020;
+  ZMQ_EVENT_ACCEPT_FAILED   = $0040;
+  ZMQ_EVENT_CLOSED          = $0080;
+  ZMQ_EVENT_CLOSE_FAILED    = $0100;
+  ZMQ_EVENT_DISCONNECTED    = $0200;
+  ZMQ_EVENT_MONITOR_STOPPED = $0400;
+  ZMQ_EVENT_ALL             = $FFFF;
+
+  function zmq_socket(P: Pointer; atype: integer) : Pointer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_close(s: Pointer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_setsockopt(s: Pointer; option: integer; const optval: Pointer;
+      optvallen: LongWord) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_getsockopt(s: Pointer; option: integer; optval : Pointer;
+      optvallen: LongWord) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_bind(s: Pointer; const addr: PChar) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_connect(s: Pointer; const addr: PChar) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_unbind(s: Pointer; const addr: PChar) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_disconnect(s: Pointer; const addr: PChar) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_send(s: Pointer; const buf: Pointer; len: LongWord; flags: integer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_send_const(s: Pointer; const buf: Pointer; len: LongWord; flags: integer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_recv(s: Pointer; buf: Pointer; len: LongWord; flags: integer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_socket_monitor(s: Pointer; const addr: PChar; events: integer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+{
+    /******************************************************************************/
+    /*  Deprecated I/O multiplexing. Prefer using zmq_poller API                  */
+    /******************************************************************************/
+}
+const
+  ZMQ_POLLIN = 1 deprecated 'Deprecated I/O multiplexing. Prefer using zmq_poller API';
+  ZMQ_POLLOUT = 2 deprecated 'Deprecated I/O multiplexing. Prefer using zmq_poller API';
+  ZMQ_POLLERR = 4 deprecated 'Deprecated I/O multiplexing. Prefer using zmq_poller API';
+  ZMQ_POLLPRI = 8 deprecated 'Deprecated I/O multiplexing. Prefer using zmq_poller API';
+
+type zmq_pollitem_t = packed record
+  socket: Pointer;
+{$IFDEF WIN32}
+  fd: LongWord;
+{$ELSE}
+  fd: integer;
+{$ENDIF}
+  events: Smallint;
+  revents: Smallint;
+end;
+
+const
+  ZMQ_POLLITEMS_DFLT = 16 deprecated 'Deprecated I/O multiplexing. Prefer using zmq_poller API';
+
+  function zmq_poll(var items: zmq_pollitem_t; nitems: integer; timeout: LongInt ) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF}; deprecated 'Deprecated I/O multiplexing. Prefer using zmq_poller API';
+{
+  /******************************************************************************/
+  /*  Message proxying                                                          */
+  /******************************************************************************/
+}
+
+  function zmq_proxy(frontend: Pointer; backend: Pointer; capture: Pointer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_proxy_steerable(frontend: Pointer; backend: Pointer;
+      capture: Pointer; control: Pointer): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+{
+  /******************************************************************************/
+  /*  Probe library capabilities                                                */
+  /******************************************************************************/
+}
+const
+  ZMQ_HAS_CAPABILITIES = 1;
+
+  function zmq_has(const capability: PChar) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+{
+  /*  Deprecated aliases */
+}
+const
+  ZMQ_STREAMER = 1 deprecated;
+  ZMQ_FORWARDER = 2 deprecated;
+  ZMQ_QUEUE = 3 deprecated;
+
+{
+  /*  Deprecated methods */
+}
+
+  function zmq_device(atype: integer; frontend: Pointer; backend: Pointer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF}; deprecated;
+  function zmq_sendmsg(s: Pointer; var msg: zmq_msg_t; flags: integer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF}; deprecated;
+  function zmq_recvmsg(s: Pointer; var msg: zmq_msg_t; flags: integer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF}; deprecated;
+
+type iovec = record end;
+  function zmq_sendiov(s: Pointer; iov: iovec; count: LongWord; flags: integer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF}; deprecated;
+  function zmq_recviov(s: Pointer; iov: iovec; count: LongWord; flags: integer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF}; deprecated;
+
+{
+  /******************************************************************************/
+  /*  Encryption functions                                                      */
+  /******************************************************************************/
+}
+
+  {
+  /*  Encode data with Z85 encoding. Returns encoded data                       */
+  }
+  function zmq_z85_encode(dest: PChar; const data: PByte; size: LongWord) : PChar; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+  {
+  /*  Decode data with Z85 encoding. Returns decoded data                       */
+  }
+  function zmq_z85_decode(dest: PByte; const astring: PChar) : PByte; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+  {
+  /*  Generate z85-encoded public and private keypair with tweetnacl/libsodium. */
+  /*  Returns 0 on success.                                                     */
+  }
+  function zmq_curve_keypair(z85_public_key: PChar; z85_secret_key: PChar) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+  {
+  /*  Derive the z85-encoded public key from the z85-encoded secret key.        */
+  /*  Returns 0 on success.                                                     */
+  }
+  function zmq_curve_public(z85_public_key: PChar; const z85_secret_key: PChar) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+{
+  /******************************************************************************/
+  /*  Atomic utility methods                                                    */
+  /******************************************************************************/
+}
+
+  function zmq_atomic_counter_new : Pointer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  procedure zmq_atomic_counter_set(counter: Pointer; value: integer); cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_atomic_counter_inc(counter: Pointer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_atomic_counter_dec(counter: Pointer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_atomic_counter_value (counter: Pointer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  procedure zmq_atomic_counter_destroy(counter_p: PPointer); cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+{
+  /******************************************************************************/
+  /*  These functions are not documented by man pages -- use at your own risk.  */
+  /*  If you need these to be part of the formal ZMQ API, then (a) write a man  */
+  /*  page, and (b) write a test case in tests.                                 */
+  /******************************************************************************/
+
+  /*  Helper functions are used by perf tests so that they don't have to care   */
+  /*  about minutiae of time-related functions on different OS platforms.       */
+}
+  {
+  /*  Starts the stopwatch. Returns the handle to the watch.                    */
+  }
+  function zmq_stopwatch_start : Pointer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+  {
+  /*  Stops the stopwatch. Returns the number of microseconds elapsed since     */
+  /*  the stopwatch was started.                                                */
+  }
+  function zmq_stopwatch_stop(watch: Pointer) : {$IFDEF CPU32} LongWord {$ENDIF} {$IFDEF CPU64} QWord {$ENDIF}; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+  {
+  /*  Sleeps for specified number of seconds.                                   */
+  }
+  procedure zmq_sleep(seconds: integer); cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+type zmq_thread_fn = procedure(P: Pointer);
+
+  {
+  /* Start a thread. Returns a handle to the thread.                            */
+  }
+  function zmq_threadstart(func: zmq_thread_fn; arg: Pointer) : Pointer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+  {
+  /* Wait for thread to complete then free up resources.                        */
+  }
+  procedure zmq_threadclose(thread: Pointer); cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+{
+  /******************************************************************************/
+  /*  These functions are DRAFT and disabled in stable releases, and subject to */
+  /*  change at ANY time until declared stable.                                 */
+  /******************************************************************************/
+
+  /*  DRAFT Socket types.                                                       */
+}
+const
+  ZMQ_SERVER = 12 experimental;
+  ZMQ_CLIENT = 13 experimental;
+  ZMQ_RADIO = 14 experimental;
+  ZMQ_DISH = 15 experimental;
+  ZMQ_GATHER = 16 experimental;
+  ZMQ_SCATTER = 17 experimental;
+  ZMQ_DGRAM = 18 experimental;
+
+{
+  /*  DRAFT 0MQ socket events and monitoring                                    */
+}
+
+  ZMQ_EVENT_HANDSHAKE_FAILED  = $0800 experimental;
+  ZMQ_EVENT_HANDSHAKE_SUCCEED = $1000 experimental;
+
+{
+  /*  DRAFT Context options                                                     */
+}
+  ZMQ_MSG_T_SIZE = 6 experimental;
+
+{
+  /*  DRAFT Socket methods.                                                     */
+}
+
+  function zmq_join(s: Pointer; const group: PChar) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF}; experimental;
+  function zmq_leave(s: Pointer; const group: PChar) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF}; experimental;
+
+{
+  /*  DRAFT Msg methods.                                                        */
+}
+
+  function zmq_msg_set_routing_id(var msg: zmq_msg_t; routing_id: LongWord) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF}; experimental;
+  function zmq_msg_routing_id(var msg: zmq_msg_t) : LongWord; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF}; experimental;
+  function zmq_msg_set_group(var msg: zmq_msg_t; const group: PChar) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF}; experimental;
+  function zmq_msg_group(var msg: zmq_msg_t) : PChar; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF}; experimental;
+
+{
+  /******************************************************************************/
+  /*  Poller polling on sockets,fd and thread-safe sockets                      */
+  /******************************************************************************/
+}
+
+type zmq_poller_event_t = packed record
+  socket: Pointer;
+  {$IFDEF WIN32}
+    fd: LongWord;
+  {$ELSE}
+    fd: integer;
+  {$ENDIF}
+  user_data: Pointer;
+  events: Smallint;
+end;
+
+  function zmq_poller_new : Pointer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_poller_destroy(poller_p : PPointer): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_poller_add(poller: Pointer; socket: Pointer; user_data: Pointer; events: ShortInt): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_poller_modify(poller: Pointer; socket: Pointer; events: ShortInt): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_poller_remove(poller: Pointer; socket: Pointer): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_poller_wait(poller: Pointer; var event: zmq_poller_event_t; timeout: LongInt): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_poller_wait_all(poller: Pointer; var events: zmq_poller_event_t;
+      n_events: integer; timeout: LongInt): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+  {$IFDEF WIN32}
+  function zmq_poller_add_fd (poller: Pointer; fd: LongWord; user_data: Pointer; events: ShortInt): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_poller_modify_fd (poller: Pointer; fd: LongWord; events: ShortInt): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_poller_remove_fd (poller: Pointer; fd: LongWord): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  {$ELSE}
+  function zmq_poller_add_fd(poller: Pointer; fd: integer; user_data: Pointer; events: ShortInt): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_poller_modify_fd(poller: Pointer; fd: integer; events: ShortInt): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_poller_remove_fd(poller: Pointer; fd: integer): integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  {$ENDIF}
+
+{
+  /******************************************************************************/
+  /*  Scheduling timers                                                         */
+  /******************************************************************************/
+}
+
+  type zmq_timer_fn = procedure (timer_id: integer; arg: Pointer);
+
+  function zmq_timers_new : Pointer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_timers_destroy(timers_p: PPointer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_timers_add(timers: Pointer; interval: LongWord; handler: zmq_timer_fn; arg: Pointer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_timers_cancel(timers: Pointer; timer_id: integer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_timers_set_interval(timers: Pointer; timer_id: integer; interval: LongWord) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_timers_reset(timers: Pointer; timer_id: integer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_timers_timeout(timers: Pointer) : LongInt; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+  function zmq_timers_execute(timers: Pointer) : integer; cdecl; external {$IFNDEF ZMQ_STATIC_LINK}libzmq{$ENDIF};
+
+{
+  /******************************************************************************/
+  /*  GSSAPI socket options to set name type                                    */
+  /******************************************************************************/
+}
+
+const
+  ZMQ_GSSAPI_PRINCIPAL_NAMETYPE = 90;
+  ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE = 91;
+
+{
+  /*  GSSAPI principal name types                                               */
+}
+
+  ZMQ_GSSAPI_NT_HOSTBASED = 0;
+  ZMQ_GSSAPI_NT_USER_NAME = 1;
+  ZMQ_GSSAPI_NT_KRB5_PRINCIPAL = 2;
+
+implementation
+
+end.

--- a/examples/Free Pascal/zmq.types.pas
+++ b/examples/Free Pascal/zmq.types.pas
@@ -1,0 +1,19 @@
+unit zmq.types;
+
+{$mode objfpc}{$H+}
+
+interface
+
+type TRandOf = function(Number : Integer): Integer;
+type TZMQRecvStringFunction = function(Socket : Pointer) : string;
+type TZMQSendStringFunction = function(Socket : Pointer; const AString : String): integer;
+type TZMQSocketProcedure = procedure(Socket : Pointer);
+
+{$IFDEF Win32}
+type TZMQSetIDProcedure = procedure(Socket : Pointer; id : PtrInt);
+{$ENDIF}
+
+implementation
+
+end.
+


### PR DESCRIPTION
Hi everyone,

What should I do to include a Free Pascal version in the examples? This PR have examples for the Free Pascal compiler. They have point-to-point correspondence to zmq names in C (no czmq though). I found it easier to follow the guide this way.

Please, make known if I can improve it.

Best regards,