### PR TITLE
Use set with sockopt routing id instead of ZMQ_IDENTITY (deprecated w…

### DIFF
--- a/examples/C++/asyncsrv.cpp
+++ b/examples/C++/asyncsrv.cpp
@@ -31,7 +31,7 @@ public:
         char identity[10] = {};
         sprintf(identity, "%04X-%04X", within(0x10000), within(0x10000));
         printf("%s\n", identity);
-        client_socket_.setsockopt(ZMQ_IDENTITY, identity, strlen(identity));
+        client_socket_.set(zmq::sockopt::routing_id, identity);
         client_socket_.connect("tcp://localhost:5570");
 
         zmq::pollitem_t items[] = {

--- a/examples/C++/identity.cpp
+++ b/examples/C++/identity.cpp
@@ -21,7 +21,7 @@ int main () {
 
     //  Then set the identity ourselves
     zmq::socket_t identified (context, ZMQ_REQ);
-    identified.setsockopt( ZMQ_IDENTITY, "PEER2", 5);
+    identified.set( zmq::sockopt::routing_id, "PEER2");
     identified.connect( "inproc://example");
 
     s_send (identified, std::string("ROUTER socket uses REQ's socket identity"));

--- a/examples/C++/tripping.cpp
+++ b/examples/C++/tripping.cpp
@@ -14,7 +14,7 @@ client_task (void *args)
 {
     zmq::context_t context (1);
     zmq::socket_t client (context, ZMQ_DEALER);
-    client.setsockopt (ZMQ_IDENTITY, "C", 1);
+    client.set(zmq::sockopt::routing_id, "C");
     client.connect ("tcp://localhost:5555");
 
     std::cout << "Setting up test..." << std::endl;
@@ -51,7 +51,7 @@ worker_task (void *args)
 {
     zmq::context_t context (1);
     zmq::socket_t worker (context, ZMQ_DEALER);
-    worker.setsockopt (ZMQ_IDENTITY, "W", 1);
+    worker.set(zmq::sockopt::routing_id, "W");
     worker.connect ("tcp://localhost:5556");
 
     while (1) {

--- a/examples/C++/zhelpers.hpp
+++ b/examples/C++/zhelpers.hpp
@@ -219,7 +219,7 @@ s_set_id (zmq::socket_t & socket)
     ss << std::hex << std::uppercase
        << std::setw(4) << std::setfill('0') << within (0x10000) << "-"
        << std::setw(4) << std::setfill('0') << within (0x10000);
-    socket.setsockopt(ZMQ_IDENTITY, ss.str().c_str(), ss.str().length());
+    socket.set(zmq::sockopt::routing_id, ss.str().c_str());
     return ss.str();
 }
 #else
@@ -230,7 +230,7 @@ s_set_id(zmq::socket_t & socket, intptr_t id)
     std::stringstream ss;
     ss << std::hex << std::uppercase
         << std::setw(4) << std::setfill('0') << id;
-    socket.setsockopt(ZMQ_IDENTITY, ss.str().c_str(), ss.str().length());
+    socket.set(zmq::sockopt::routing_id, ss.str().c_str());
     return ss.str();
 }
 #endif


### PR DESCRIPTION
…arning)