### PR TITLE
rust examples. actualized cargo meta for rust 2021 edition

### DIFF
--- a/examples/Rust/Cargo.lock
+++ b/examples/Rust/Cargo.lock
@@ -3,22 +3,16 @@
 version = 3
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "bitflags"
-version = "1.0.4"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 dependencies = [
  "jobserver",
  "libc",
@@ -26,19 +20,13 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.15.4"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40ccee03b5175c18cde8f37e7d2a33bcef6f8ec8f7cc0d81090d1bb380949c9"
+checksum = "fa50868b64a9a6fda9d593ce778849ea8715cd2a3d2cc17ffdb4a2f2f2f1961d"
 dependencies = [
  "smallvec",
  "target-lexicon",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 
 [[package]]
 name = "cfg-if"
@@ -48,11 +36,10 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crossbeam"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
 dependencies = [
- "cfg-if 1.0.0",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -62,62 +49,52 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.8"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
- "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
- "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "dircpy"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8466f8d28ca6da4c9dfbbef6ad4bff6f2fdd5e412d821025b0d3f0a9d74a8c1e"
+checksum = "29259db751c34980bfc44100875890c507f585323453b91936960ab1104272ca"
 dependencies = [
  "jwalk",
  "log",
@@ -126,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "equivalent"
@@ -137,26 +114,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
+name = "getrandom"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
@@ -165,16 +137,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
-
-[[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -182,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
 ]
@@ -201,84 +167,87 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "log"
-version = "0.4.6"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
-dependencies = [
- "cfg-if 0.1.6",
-]
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
-
-[[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.14"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.4.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "fuchsia-zircon",
  "libc",
- "winapi",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -286,14 +255,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -314,25 +281,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -341,24 +302,24 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "syn"
-version = "2.0.31"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -367,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "6.1.1"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c2de8a4d8f4b823d634affc9cd2a74ec98c53a756f317e529a48046cbf71f3"
+checksum = "2a2d580ff6a20c55dfb86be5f9c238f67835d0e81cbdea8bf5680e0897320331"
 dependencies = [
  "cfg-expr",
  "heck",
@@ -380,15 +341,15 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.11"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "toml"
-version = "0.7.6"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -398,18 +359,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
 dependencies = [
  "indexmap",
  "serde",
@@ -420,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "version-compare"
@@ -432,19 +393,25 @@ checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.6"
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -458,9 +425,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -473,9 +440,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winnow"
-version = "0.5.15"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]

--- a/examples/Rust/Cargo.toml
+++ b/examples/Rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust-examples"
 version = "0.1.0"
 authors = ["CjS77 <cayle.sharrock@gmail.com>"]
+edition = "2021"
 
 [[bin]]
 path = "./hwclient.rs"
@@ -101,4 +102,4 @@ name = "wuserver"
 
 [dependencies]
 zmq = "0.10"
-rand = "0.4"
+rand = "0.8"

--- a/examples/Rust/hwclient.rs
+++ b/examples/Rust/hwclient.rs
@@ -1,7 +1,3 @@
-#![crate_name = "hwclient"]
-
-extern crate zmq;
-
 fn main() {
     println!("Connecting to hello world server...");
     let context = zmq::Context::new();

--- a/examples/Rust/hwserver.rs
+++ b/examples/Rust/hwserver.rs
@@ -1,7 +1,3 @@
-#![crate_name = "hwserver"]
-
-extern crate zmq;
-
 use std::{thread, time};
 
 fn main() {

--- a/examples/Rust/interrupt.rs
+++ b/examples/Rust/interrupt.rs
@@ -1,11 +1,6 @@
-#![crate_name = "interrupt"]
-
-extern crate nix;
-extern crate zmq;
-
+use nix::sys::signal;
 use std::os::unix::io::RawFd;
 use std::process;
-use nix::sys::signal;
 
 static mut S_FD: RawFd = -1;
 

--- a/examples/Rust/lpclient.rs
+++ b/examples/Rust/lpclient.rs
@@ -1,8 +1,4 @@
-#![crate_name = "lpclient"]
-
-use std::time::Duration;
 use std::convert::TryInto;
-extern crate zmq;
 
 const REQUEST_TIMEOUT: i64 = 2500;
 const REQUEST_RETRIES: usize = 3;

--- a/examples/Rust/lpserver.rs
+++ b/examples/Rust/lpserver.rs
@@ -1,9 +1,5 @@
-#![crate_name = "lpserver"]
-
 use rand::{thread_rng, Rng};
 use std::time::Duration;
-extern crate rand;
-extern crate zmq;
 
 fn main() {
     let context = zmq::Context::new();
@@ -18,12 +14,12 @@ fn main() {
         server.send(request, 0).unwrap();
         std::thread::sleep(Duration::from_secs(1));
 
-        if (i > 3) && (thread_rng().gen_range(0, 3) == 0) {
+        if (i > 3) && (thread_rng().gen_range(0..3) == 0) {
             // simulate a crash
             println!("Oh no! Server crashed.");
             break;
         }
-        if (i > 3) && (thread_rng().gen_range(0, 3) == 0) {
+        if (i > 3) && (thread_rng().gen_range(0..3) == 0) {
             // simulate overload
             println!("Server is busy.");
             std::thread::sleep(Duration::from_secs(2));

--- a/examples/Rust/msgqueue.rs
+++ b/examples/Rust/msgqueue.rs
@@ -1,7 +1,3 @@
-#![crate_name = "msgqueue"]
-
-extern crate zmq;
-
 fn main() {
     let context = zmq::Context::new();
 

--- a/examples/Rust/mspoller.rs
+++ b/examples/Rust/mspoller.rs
@@ -1,7 +1,3 @@
-#![crate_name = "mspoller"]
-
-extern crate zmq;
-
 fn main() {
     let context = zmq::Context::new();
 

--- a/examples/Rust/msreader.rs
+++ b/examples/Rust/msreader.rs
@@ -1,7 +1,3 @@
-#![crate_name = "msreader"]
-
-extern crate zmq;
-
 use std::{thread, time};
 
 fn main() {

--- a/examples/Rust/mtrelay.rs
+++ b/examples/Rust/mtrelay.rs
@@ -1,7 +1,3 @@
-#![crate_name = "mtrelay"]
-
-extern crate zmq;
-
 use std::thread;
 
 fn step1(context: &zmq::Context) {

--- a/examples/Rust/mtserver.rs
+++ b/examples/Rust/mtserver.rs
@@ -1,7 +1,3 @@
-#![crate_name = "mtserver"]
-
-extern crate zmq;
-
 use std::{thread, time};
 
 fn worker_routine(context: &zmq::Context) {

--- a/examples/Rust/psenvpub.rs
+++ b/examples/Rust/psenvpub.rs
@@ -1,7 +1,3 @@
-#![crate_name = "psenvpub"]
-
-extern crate zmq;
-
 use std::{thread, time};
 
 fn main() {

--- a/examples/Rust/psenvsub.rs
+++ b/examples/Rust/psenvsub.rs
@@ -1,7 +1,3 @@
-#![crate_name = "psenvsub"]
-
-extern crate zmq;
-
 fn main() {
     let context = zmq::Context::new();
     let subscriber = context.socket(zmq::SUB).unwrap();

--- a/examples/Rust/rrbroker.rs
+++ b/examples/Rust/rrbroker.rs
@@ -1,7 +1,3 @@
-#![crate_name = "rrbroker"]
-
-extern crate zmq;
-
 fn main() {
     let context = zmq::Context::new();
     let frontend = context.socket(zmq::ROUTER).unwrap();

--- a/examples/Rust/rrclient.rs
+++ b/examples/Rust/rrclient.rs
@@ -1,7 +1,3 @@
-#![crate_name = "rrclient"]
-
-extern crate zmq;
-
 fn main() {
     let context = zmq::Context::new();
 

--- a/examples/Rust/rrworker.rs
+++ b/examples/Rust/rrworker.rs
@@ -1,7 +1,3 @@
-#![crate_name = "rrworker"]
-
-extern crate zmq;
-
 use std::{thread, time};
 
 fn main() {

--- a/examples/Rust/syncpub.rs
+++ b/examples/Rust/syncpub.rs
@@ -1,5 +1,3 @@
-extern crate zmq;
-
 fn main() {
     const SUBSCRIBERS_EXPECTED: usize = 10;
     let context = zmq::Context::new();

--- a/examples/Rust/syncsub.rs
+++ b/examples/Rust/syncsub.rs
@@ -1,5 +1,3 @@
-extern crate zmq;
-
 use std::thread;
 use std::time::Duration;
 

--- a/examples/Rust/tasksink.rs
+++ b/examples/Rust/tasksink.rs
@@ -1,7 +1,3 @@
-#![crate_name = "tasksink"]
-
-extern crate zmq;
-
 use std::io::{self, Write};
 use std::time::Instant;
 

--- a/examples/Rust/taskvent.rs
+++ b/examples/Rust/taskvent.rs
@@ -1,8 +1,3 @@
-#![crate_name = "taskvent"]
-
-extern crate rand;
-extern crate zmq;
-
 use rand::Rng;
 use std::io::{self, BufRead};
 use std::{thread, time};
@@ -22,11 +17,11 @@ fn main() {
 
     sink.send("0", 0).unwrap();
 
-    let mut rng = rand::weak_rng();
+    let mut rng = rand::thread_rng();
 
     let mut total_msec = 0;
     for _ in 0..100 {
-        let workload = rng.gen_range(1, 101);
+        let workload = rng.gen_range(1..101);
         total_msec += workload;
         let string = format!("{}", workload);
         sender.send(&string, 0).unwrap();

--- a/examples/Rust/taskwork.rs
+++ b/examples/Rust/taskwork.rs
@@ -1,7 +1,3 @@
-#![crate_name = "taskwork"]
-
-extern crate zmq;
-
 use std::io::{self, Write};
 use std::{thread, time};
 

--- a/examples/Rust/taskwork2.rs
+++ b/examples/Rust/taskwork2.rs
@@ -1,7 +1,3 @@
-#![crate_name = "taskwork2"]
-
-extern crate zmq;
-
 use std::io::{self, Write};
 use std::{thread, time};
 

--- a/examples/Rust/version.rs
+++ b/examples/Rust/version.rs
@@ -1,7 +1,3 @@
-#![crate_name = "version"]
-
-extern crate zmq;
-
 fn main() {
     let (major, minor, patch) = zmq::version();
     println!("Current 0MQ version is {}.{}.{}", major, minor, patch);

--- a/examples/Rust/wuclient.rs
+++ b/examples/Rust/wuclient.rs
@@ -1,7 +1,3 @@
-#![crate_name = "wuclient"]
-
-extern crate zmq;
-
 use std::env;
 
 fn atoi(s: &str) -> i64 {

--- a/examples/Rust/wuproxy.rs
+++ b/examples/Rust/wuproxy.rs
@@ -1,7 +1,3 @@
-#![crate_name = "wuproxy"]
-
-extern crate zmq;
-
 fn main() {
     let context = zmq::Context::new();
 

--- a/examples/Rust/wuserver.rs
+++ b/examples/Rust/wuserver.rs
@@ -1,8 +1,3 @@
-#![crate_name = "wuserver"]
-
-extern crate rand;
-extern crate zmq;
-
 use rand::Rng;
 
 fn main() {
@@ -10,12 +5,12 @@ fn main() {
     let publisher = context.socket(zmq::PUB).unwrap();
     assert!(publisher.bind("tcp://*:5556").is_ok());
 
-    let mut rng = rand::weak_rng();
+    let mut rng = rand::thread_rng();
 
     loop {
-        let zipcode = rng.gen_range(0, 100000);
-        let temperature = rng.gen_range(-80, 135);
-        let relhumidity = rng.gen_range(10, 60);
+        let zipcode = rng.gen_range(0..100000);
+        let temperature = rng.gen_range(-80..135);
+        let relhumidity = rng.gen_range(10..60);
 
         let update = format!("{:05} {} {}", zipcode, temperature, relhumidity);
         publisher.send(&update, 0).unwrap();


### PR DESCRIPTION
updated code to modern cargo usage:
- removed non required explicit externs
- removed non required attributes 

updated rand crate dependency and it's usage