### PR TITLE
Problem:  Wrong else statement

### DIFF
--- a/examples/Python/wuclient.py
+++ b/examples/Python/wuclient.py
@@ -16,7 +16,7 @@ print("Collecting updates from weather server...")
 socket.connect("tcp://localhost:5556")
 
 # Subscribe to zipcode, default is NYC, 10001
-zip_filter = sys.argv[1] if len(sys.argv) > 1 else "10001"
+zip_filter = sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] == "10001"
 socket.setsockopt_string(zmq.SUBSCRIBE, zip_filter)
 
 # Process 5 updates


### PR DESCRIPTION
Solution:
Replace the wrong else statement with the correct and statment. Otherwise the filter would always set "1001" as a default statement.