### PR TITLE
Added "path" to languages.yaml to get the correct paths for F# and C#

### DIFF
--- a/site/data/languages.yaml
+++ b/site/data/languages.yaml
@@ -1,51 +1,75 @@
 - name: Ada
   extension: ada
+  path: Ada
 - name: Basic
   extension: bas
+  path: Basic
 - name: C
   extension: c
+  path: C
 - name: C++
   extension: cpp
+  path: C++
 - name: C#
   extension: cs
+  path: CSharp
 - name: CL
   extension: lisp
+  path: CL
 - name: Delphi
   extension: dpr
+  path: Delphi
 - name: Erlang
   extension: es
+  path: Erlang
 - name: Elixir
   extension: exs
+  path: Elixir
 - name: F#
   extension: fsx
+  path: FSharp
 - name: Felix
   extension: flx
+  path: Felix
 - name: Go
   extension: go
+  path: Go
 - name: Haskell
   extension: hs
+  path: Haskell
 - name: Haxe
   extension: hx
+  path: Haxe
 - name: Java
   extension: java
+  path: Java
 - name: Julia
   extension: jl
+  path: Julia
 - name: Lua
   extension: lua
+  path: Lua
 - name: Node.js
   extension: js
+  path: Node.js
 - name: Objective-C
   extension: m
+  path: Objective-C
 - name: ooc
   extension: ooc
+  path: ooc
 - name: Perl
   extension: pl
+  path: Perl
 - name: PHP
   extension: php
+  path: PHP
 - name: Python
   extension: py
+  path: Python
 - name: Q
   extension: q
+  path: Q
 - name: Racket
   extension: rkt
 - name: Ruby

--- a/site/layouts/shortcodes/example.html
+++ b/site/layouts/shortcodes/example.html
@@ -6,7 +6,8 @@
 {{ range where $languages "name" $language }}
   {{ $languageName := .name }}
   {{ $languageExtension := .extension }}
-  {{ $examplePath := printf "/content/examples/%s/%s.%s" $languageName $name $languageExtension | safeURL }}
+  {{ $languageExamplePath := .path }}
+  {{ $examplePath := printf "/content/examples/%s/%s.%s" $languageExamplePath $name $languageExtension | safeURL }}
   <details open>
     <summary>{{ $name }}: {{ $title }} in {{ $languageName }}</summary>
       {{ if fileExists $examplePath }}
@@ -14,7 +15,7 @@
             {{ highlight (readFile $examplePath) $languageName "" }}
           </div>
           <div class="book-footer" style="padding: 0">
-              <a class="flex align-center" href="{{ $s.Params.BookRepo }}/edit/master/{{ printf "/examples/%s/%s.%s" $languageName $name $languageExtension | safeURL }}" target="_blank" rel="noopener">
+              <a class="flex align-center" href="{{ $s.Params.BookRepo }}/edit/master/{{ printf "/examples/%s/%s.%s" $languageExamplePath $name $languageExtension | safeURL }}" target="_blank" rel="noopener">
               <img src="{{ "svg/edit.svg" | relURL }}" class="book-icon" alt="Edit" />
               <span>Edit this example</span>
             </a>

--- a/site/layouts/shortcodes/examples.html
+++ b/site/layouts/shortcodes/examples.html
@@ -10,7 +10,7 @@
   {{ $languageExamplePath := .path }}
   {{ $examplePath := printf "/content/examples/%s/%s.%s" $languageExamplePath $name $languageExtension | safeURL }}
   <details class="example" data-language="{{ $languageName }}" style="display: none">
-    <summary>{{ $name }}: {{ $title }} in {{ $languageName }} ({{ $examplePath }})</summary>
+    <summary>{{ $name }}: {{ $title }} in {{ $languageName }}</summary>
       
       {{ if fileExists $examplePath }}
         {{ $languagesWithExample = $languagesWithExample | append . }}
@@ -18,7 +18,7 @@
             {{ highlight (readFile $examplePath) $languageName "" }}
           </div>
           <div class="book-footer" style="padding: 0">
-              <a class="flex align-center" href="{{ $s.Params.BookRepo }}/edit/master/{{ printf "/examples/%s/%s.%s" $languageName $name $languageExtension | safeURL }}" target="_blank" rel="noopener">
+              <a class="flex align-center" href="{{ $s.Params.BookRepo }}/edit/master/{{ printf "/examples/%s/%s.%s" $languageExamplePath $name $languageExtension | safeURL }}" target="_blank" rel="noopener">
               <img src="{{ "svg/edit.svg" | relURL }}" class="book-icon" alt="Edit" />
               <span>Edit this example</span>
             </a>

--- a/site/layouts/shortcodes/examples.html
+++ b/site/layouts/shortcodes/examples.html
@@ -7,9 +7,11 @@
 {{ range $languages }}
   {{ $languageName := .name }}
   {{ $languageExtension := .extension }}
-  {{ $examplePath := printf "/content/examples/%s/%s.%s" $languageName $name $languageExtension | safeURL }}
+  {{ $languageExamplePath := .path }}
+  {{ $examplePath := printf "/content/examples/%s/%s.%s" $languageExamplePath $name $languageExtension | safeURL }}
   <details class="example" data-language="{{ $languageName }}" style="display: none">
-    <summary>{{ $name }}: {{ $title }} in {{ $languageName }}</summary>
+    <summary>{{ $name }}: {{ $title }} in {{ $languageName }} ({{ $examplePath }})</summary>
+      
       {{ if fileExists $examplePath }}
         {{ $languagesWithExample = $languagesWithExample | append . }}
           <div class="markdown-inner">


### PR DESCRIPTION
Since the renaming of the examples directories for F# and C# the examples are not rendered anymore.
To fix this, I added a property "path" to the values of the languages.yaml that contains the subpath of the examples dir that contains that languages examples.