### PR TITLE
Problem: Syntax errors and logic flaws introduced in Commit #4130393

### DIFF
--- a/examples/Python/wuclient.py
+++ b/examples/Python/wuclient.py
@@ -16,7 +16,7 @@ print("Collecting updates from weather server...")
 socket.connect("tcp://localhost:5556")
 
 # Subscribe to zipcode, default is NYC, 10001
-zip_filter = sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] == "10001"
+zip_filter = sys.argv[1] if len(sys.argv) > 1 else "10001"
 socket.setsockopt_string(zmq.SUBSCRIBE, zip_filter)
 
 # Process 5 updates


### PR DESCRIPTION
Solution: Revert to the code state prior to Commit 4130393; the previous code functioned as expected.

![image](https://github.com/user-attachments/assets/d36ee1cf-d4d9-4934-aa25-a4b546b32dcd)
