### PR TITLE
Update hwserver.c for readability -- name constants and variables

### DIFF
--- a/examples/C/hwserver.c
+++ b/examples/C/hwserver.c
@@ -11,15 +11,17 @@ int main (void)
     //  Socket to talk to clients
     void *context = zmq_ctx_new ();
     void *responder = zmq_socket (context, ZMQ_REP);
-    int rc = zmq_bind (responder, "tcp://*:5555");
-    assert (rc == 0);
+    int response = zmq_bind (responder, "tcp://*:5555");
+    assert (response == 0); // Check if the response code indicates success
 
     while (1) {
-        char buffer [10];
-        zmq_recv (responder, buffer, 10, 0);
+        static const size_t kReadBufferLength = 10;
+        char buffer [kReadBufferLength];
+        zmq_recv (responder, buffer, kReadBufferLength, 0);
         printf ("Received Hello\n");
-        sleep (1);          //  Do some 'work'
-        zmq_send (responder, "World", 5, 0);
+        sleep (1);          //  Pretend to do some 'work'
+        static const char kReplyString[] = "World";
+        zmq_send(responder, kReplyString, sizeof(kReplyString) - 1, 0);
     }
     return 0;
 }


### PR DESCRIPTION
There were several constants in the code that were magic numbers. The new code makes it clear which ones are dependent on each other. I also replaced "rc" with "response" to avoid a convention that not everyone may know. 

I do wish that the "0" for flags in zmq_recv and zmq_send had a proper #define somewhere. If there was a `#define ZMQ_NOFLAGS 0` then it would be easier for people to look up the header file containing all the flag options that are valid for these functions from code. But that doesn't exist, so I left the zeros.