### PR TITLE
Replace deprecated _internal/google_analytics_async.html

### DIFF
--- a/site/themes/book/layouts/404.html
+++ b/site/themes/book/layouts/404.html
@@ -29,7 +29,7 @@
     </main>
 
     {{ partial "docs/inject/body" . }}
-    {{ template "_internal/google_analytics_async.html" . }}
+    {{ template "_internal/google_analytics.html" . }}
   </body>
 
   </html>

--- a/site/themes/book/layouts/partials/docs/html-head.html
+++ b/site/themes/book/layouts/partials/docs/html-head.html
@@ -30,7 +30,7 @@
 <script defer src="{{ $swJS.RelPermalink }}" integrity="{{ $swJS.Data.Integrity }}"></script>
 {{ end -}}
 
-{{- template "_internal/google_analytics_async.html" . -}}
+{{- template "_internal/google_analytics.html" . -}}
 
 <!-- RSS -->
 {{- with .OutputFormats.Get "rss" -}}


### PR DESCRIPTION
Fix build error due to deprecated `_internal/google_analytics_async.html`
```
dev@dev-ws01:~/Git/zguide$ make
cd site && \
hugo server \
--buildDrafts \
--buildFuture \
--disableFastRender \
--ignoreCache \
--theme book
Watching for changes in /home/dev/Git/zguide/site/{archetypes,assets,content,data,layouts,static,themes}
Watching for config changes in /home/dev/Git/zguide/site/config.toml
Start building sites … 
hugo v0.131.0+extended linux/amd64 BuildDate=2024-09-03T01:15:37Z VendorInfo=debian:0.131.0-1

ERROR render of "404" failed: execute of template failed: html/template:404.html:32:16: no such template "_internal/google_analytics_async.html"
ERROR render of "section" failed: "/home/dev/Git/zguide/site/themes/book/layouts/_default/baseof.html:5:5": execute of template failed: template: _default/list.html:5:5: executing "_default/list.html" at <partial "docs/html-head" .>: error calling partial: execute of template failed: html/template:partials/docs/html-head.html:33:13: no such template "_internal/google_analytics_async.html"
ERROR render of "page" failed: "/home/dev/Git/zguide/site/themes/book/layouts/_default/baseof.html:5:5": execute of template failed: template: _default/single.html:5:5: executing "_default/single.html" at <partial "docs/html-head" .>: error calling partial: execute of template failed: html/template:partials/docs/html-head.html:33:13: no such template "_internal/google_analytics_async.html"
Built in 27 ms
Error: error building site: render: failed to render pages: render of "home" failed: "/home/dev/Git/zguide/site/themes/book/layouts/_default/baseof.html:5:5": execute of template failed: template: _default/list.html:5:5: executing "_default/list.html" at <partial "docs/html-head" .>: error calling partial: execute of template failed: html/template:partials/docs/html-head.html:33:13: no such template "_internal/google_analytics_async.html"
make: *** [Makefile:2: serve] Error 1
```