### PR TITLE
add github actions workflow

### DIFF
--- a/.github/workflows/mkmarkdown.yml
+++ b/.github/workflows/mkmarkdown.yml
@@ -29,13 +29,13 @@ jobs:
       - name: Check for changes
         id: diff
         run: |
-          git diff --quiet site/content/ site/.bookmarks || echo "changed=true" >> "$GITHUB_OUTPUT"
+          git diff --quiet site/content/ || echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push regenerated markdown
         if: steps.diff.outputs.changed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add site/content/ site/.bookmarks
+          git add site/content/
           git commit -m "Regenerate markdown from source txt files"
           git push

--- a/.github/workflows/mkmarkdown.yml
+++ b/.github/workflows/mkmarkdown.yml
@@ -1,0 +1,41 @@
+name: Regenerate Markdown from Source
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '*.txt'
+      - 'zguide.book'
+      - 'bin/mkmarkdown'
+
+  workflow_dispatch:
+
+jobs:
+  mkmarkdown:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run mkmarkdown
+        run: perl bin/mkmarkdown < zguide.book
+
+      - name: Check for changes
+        id: diff
+        run: |
+          git diff --quiet site/content/ site/.bookmarks || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push regenerated markdown
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add site/content/ site/.bookmarks
+          git commit -m "Regenerate markdown from source txt files"
+          git push


### PR DESCRIPTION
This github actions workflow runs the mkmarkdown script when a commit is pushed to master that updates a txt file, zguide.book or if the mkmarkdown script is updated. If the script changes any of the markdown files, then the changes are pushed in a commit to the repo. 

As I understand it, hugo already runs on commits to master, so changes to the md files, languages.yml, and examples already are pushed to the website. This should fix the issues with updates to .txt files not propagating to the site.

- I'm not super familiar with github actions, and there might be a better way to setup the git username/email.
- Opting to exclude site/.bookmarks from the commit since it looks like hugo doesn't need this to generate the html. Let me know if that's not right.

closes #938